### PR TITLE
SLING-7692 catch Unsupported ex

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/sling/context/SlingContextImpl.java
+++ b/src/main/java/org/apache/sling/testing/mock/sling/context/SlingContextImpl.java
@@ -194,6 +194,8 @@ public class SlingContextImpl extends OsgiContextImpl {
                     session.refresh(false);
                 } catch (RepositoryException ex) {
                     // ignore
+                } catch (UnsupportedOperationException ex){
+                    // ignore
                 }
             }
             


### PR DESCRIPTION
now refresh(false) sends unsupported operation exception with jcr mock resolver type, hence we catch it here to leave other implementations being able to cancel the changes