### PR TITLE
Fix NoClassDefFoundError: ScriptEngineManagerFactory

### DIFF
--- a/core/src/main/java/org/apache/sling/testing/mock/sling/context/SlingContextImpl.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/context/SlingContextImpl.java
@@ -38,7 +38,6 @@ import org.apache.sling.resourcebuilder.api.ResourceBuilder;
 import org.apache.sling.resourcebuilder.api.ResourceBuilderFactory;
 import org.apache.sling.resourcebuilder.impl.ResourceBuilderFactoryService;
 import org.apache.sling.scripting.core.impl.BindingsValuesProvidersByContextImpl;
-import org.apache.sling.scripting.core.impl.ScriptEngineManagerFactory;
 import org.apache.sling.settings.SlingSettingsService;
 import org.apache.sling.testing.mock.osgi.MockOsgi;
 import org.apache.sling.testing.mock.osgi.context.OsgiContextImpl;
@@ -150,7 +149,9 @@ public class SlingContextImpl extends OsgiContextImpl {
     protected void registerDefaultServices() {
 
         // scripting services (required by sling models impl since 1.3.6)
-        registerInjectActivateService(new ScriptEngineManagerFactory());
+        registerInjectActivateServiceByClassName(
+                "org.apache.sling.scripting.core.impl.ScriptEngineManagerFactory",
+                "org.apache.sling.scripting.core.impl.jsr223.SlingScriptEngineManager");
         registerInjectActivateService(new BindingsValuesProvidersByContextImpl());
         
         // sling models


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/SLING-8576 : for versions of org.apache.sling.scripting.core above 2.0.50 the org.apache.sling.scripting.core.impl.ScriptEngineManagerFactory disappears, but org.apache.sling.scripting.core.impl.jsr223.SlingScriptEngineManager is needed instead. The tests succeed now both for versions 2.0.36 as well as 2.0.54 of sling.scripting.core.