### PR TITLE
SLING-11297 - The org.apache.sling.testing.mock.sling.RRMockResourceResolverWrapper should first query its providers

### DIFF
--- a/junit4/src/test/java/org/apache/sling/testing/mock/sling/junit/SlingContextDefaultRRTypeTest.java
+++ b/junit4/src/test/java/org/apache/sling/testing/mock/sling/junit/SlingContextDefaultRRTypeTest.java
@@ -18,8 +18,11 @@
  */
 package org.apache.sling.testing.mock.sling.junit;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import org.apache.sling.api.resource.Resource;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -31,6 +34,24 @@ public class SlingContextDefaultRRTypeTest {
     @Test
     public void testRequest() {
         assertNotNull(context.request());
+    }
+
+    @Test
+    public void testResourceOperationsOnMountedFolder() {
+        String root = context.uniqueRoot().content() + "/test-content";
+        context.load().folderJson("src/test/resources/test-content", root);
+
+        Resource parent = context.resourceResolver().getResource(root + "/parent");
+        assertNotNull( "Expected to resolve the 'parent' resource.", parent);
+        assertNotNull("Expected to resolver the 'child' resource.", parent.getChild("child"));
+
+        Resource uniqueRoot = context.resourceResolver().getParent(parent);
+        assertNotNull("Expected to resolve the unique root.", uniqueRoot);
+        assertEquals("The resolved unique root is not identical to the created unique root.", root, uniqueRoot.getPath());
+
+        assertTrue("Expected to see a list of children.", context.resourceResolver().listChildren(parent).hasNext());
+        assertTrue("Expected to get a list of children.", context.resourceResolver().getChildren(parent).iterator().hasNext());
+        assertTrue("Expected to see a list of children.", parent.hasChildren());
     }
 
 }

--- a/junit4/src/test/resources/test-content/parent.json
+++ b/junit4/src/test/resources/test-content/parent.json
@@ -1,0 +1,6 @@
+{
+    "jcr:primaryType": "nt:unstructured",
+    "child" : {
+        "jcr:primaryType": "nt:unstructured"
+    }
+}

--- a/junit5/src/test/java/org/apache/sling/testing/mock/sling/junit5/SlingContextTest.java
+++ b/junit5/src/test/java/org/apache/sling/testing/mock/sling/junit5/SlingContextTest.java
@@ -19,6 +19,8 @@
 package org.apache.sling.testing.mock.sling.junit5;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
@@ -53,6 +55,24 @@ class SlingContextTest {
         context.request().setAttribute("prop1", "myValue");
         ClasspathRegisteredModel model = context.request().adaptTo(ClasspathRegisteredModel.class);
         assertEquals("myValue", model.getProp1());
+    }
+
+    @Test
+    void testResourceOperationsOnMountedFolder(SlingContext context) {
+        String root = context.uniqueRoot().content() + "/test-content";
+        context.load().folderJson("src/test/resources/test-content", root);
+
+        Resource parent = context.resourceResolver().getResource(root + "/parent");
+        assertNotNull(parent, "Expected to resolve the 'parent' resource.");
+        assertNotNull(parent.getChild("child"), "Expected to resolver the 'child' resource.");
+
+        Resource uniqueRoot = context.resourceResolver().getParent(parent);
+        assertNotNull(uniqueRoot, "Expected to resolve the unique root");
+        assertEquals(root, uniqueRoot.getPath(), "The resolved unique root is not identical to the created unique root.");
+
+        assertTrue(context.resourceResolver().listChildren(parent).hasNext(), "Expected to get a list of children.");
+        assertTrue(context.resourceResolver().getChildren(parent).iterator().hasNext(), "Expected to get a list of children.");
+        assertTrue(parent.hasChildren(), "Expected to get a list of children.");
     }
 
     @AfterEach

--- a/junit5/src/test/resources/test-content/parent.json
+++ b/junit5/src/test/resources/test-content/parent.json
@@ -1,0 +1,6 @@
+{
+    "jcr:primaryType": "nt:unstructured",
+    "child" : {
+        "jcr:primaryType": "nt:unstructured"
+    }
+}


### PR DESCRIPTION
* implemented the rest of the methods that read resources
* added tests