### PR TITLE
SLING-12090 Make compatible with ResourceResolver 1.11.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -349,7 +349,7 @@
                     <dependency>
                         <groupId>org.apache.sling</groupId>
                         <artifactId>org.apache.sling.resourceresolver</artifactId>
-                        <version>1.10.0</version>
+                        <version>1.11.0</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.sling</groupId>


### PR DESCRIPTION
by waiting for completion of the asynchronous registration introduced with SLING-12019
also switch usage of Hashtable to HashMap

https://issues.apache.org/jira/browse/SLING-12090