### PR TITLE
SLING-12144 - Bump non-sling dependencies to latest in org.apache.sling.testing.sling-mock

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -192,8 +192,8 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -89,7 +89,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.2.0</version>
+                <version>5.10.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -274,12 +274,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.7.0</version>
+            <version>5.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>4.7.0</version>
+            <version>5.7.0</version>
         </dependency>
 
       </dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -222,7 +222,7 @@
         <dependency>
            <groupId>org.apache.commons</groupId>
            <artifactId>commons-collections4</artifactId>
-           <version>4.2</version>
+           <version>4.4</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -232,7 +232,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -235,9 +235,9 @@
             <version>2.11.0</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.13.0</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>


### PR DESCRIPTION
Bump dependencies:

Mockito: 4.7.0 -> 5.7.0
commons-lang 2.6 -> commons-lang3 3.13.0
commons-io 2.11.0 -> 2.13.0
commons-collectios4 4.2 -> 4.4
JUnit5 5.2.0 -> 5.10.1
