### PR TITLE
SLING-12144 - Bump commons-lang dependency to commons-lang3 (3.13.0)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -192,8 +192,8 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -235,9 +235,9 @@
             <version>2.11.0</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.13.0</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>


### PR DESCRIPTION
Broken into a separate PR,  

Removed commons-lang in favour of more recent commons-lang3.

I plan to update this in the other mock projects to 3.13.0 as well to keep them in sync.