### PR TITLE
SLING-12265 - Improve node type registration in JCR_OAK

### DIFF
--- a/core/src/test/resources/META-INF/MANIFEST.MF
+++ b/core/src/test/resources/META-INF/MANIFEST.MF
@@ -1,1 +1,4 @@
 Sling-Model-Packages: org.apache.sling.testing.mock.sling.context.modelsautoreg
+Sling-Nodetypes: SLING-INF/nodetypes/missing.cnd,
+ SLING-INF/nodetypes/syntax-error.cnd,
+ SLING-INF/nodetypes/implied-supertype.cnd

--- a/core/src/test/resources/META-INF/MANIFEST.MF
+++ b/core/src/test/resources/META-INF/MANIFEST.MF
@@ -1,4 +1,3 @@
 Sling-Model-Packages: org.apache.sling.testing.mock.sling.context.modelsautoreg
 Sling-Nodetypes: SLING-INF/nodetypes/missing.cnd,
- SLING-INF/nodetypes/syntax-error.cnd,
- SLING-INF/nodetypes/implied-supertype.cnd
+ SLING-INF/nodetypes/syntax-error.cnd

--- a/core/src/test/resources/SLING-INF/nodetypes/implied-supertype.cnd
+++ b/core/src/test/resources/SLING-INF/nodetypes/implied-supertype.cnd
@@ -1,2 +1,0 @@
-// Test case of a type that does not explicitly set a supertype.
-[sling:DummyType]

--- a/core/src/test/resources/SLING-INF/nodetypes/implied-supertype.cnd
+++ b/core/src/test/resources/SLING-INF/nodetypes/implied-supertype.cnd
@@ -1,0 +1,2 @@
+// Test case of a type that does not explicitly set a supertype.
+[sling:DummyType]

--- a/core/src/test/resources/SLING-INF/nodetypes/syntax-error.cnd
+++ b/core/src/test/resources/SLING-INF/nodetypes/syntax-error.cnd
@@ -1,0 +1,1 @@
+!!! This is a deliberately invalid CND file !!!


### PR DESCRIPTION
Instead of calling CndImporter (and triggering one commit per CND file), parse each CND file separately and register them all at once. This doesn't just reduce the number of commits, but also takes care of inter-type dependencies.