### PR TITLE
SLING-12266 - Add support for repo snapshots

### DIFF
--- a/core/src/main/java/org/apache/sling/testing/mock/sling/MockSling.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/MockSling.java
@@ -94,25 +94,31 @@ public final class MockSling {
         ResourceResolverTypeAdapter adapter = getResourceResolverTypeAdapter(type, bundleContext);
         ResourceResolverFactory factory = adapter.newResourceResolverFactory();
         if (factory == null) {
-            Object existingSnapshot = SNAPSHOTS.get(adapter.getClass());
-            SlingRepository repository;
-            if (existingSnapshot == null) {
-                repository = adapter.newSlingRepository();
-            } else {
-                repository = adapter.newSlingRepositoryFromSnapshot(existingSnapshot);
-            }
-            factory = ResourceResolverFactoryInitializer.setUp(
-                    repository,
-                    bundleContext,
-                    existingSnapshot == null ? type.getNodeTypeMode() : NodeTypeMode.NOT_SUPPORTED);
-            if (existingSnapshot == null) {
-                Object newSnapshot = adapter.snapshot(repository);
-                if (newSnapshot != null) {
-                    SNAPSHOTS.putIfAbsent(adapter.getClass(), newSnapshot);
-                }
-            }
+            factory = buildFactoryFromRepository(type.getNodeTypeMode(), bundleContext, adapter);
         } else {
             bundleContext.registerService(ResourceResolverFactory.class.getName(), factory, null);
+        }
+        return factory;
+    }
+
+    @NotNull
+    static ResourceResolverFactory buildFactoryFromRepository(
+            @NotNull NodeTypeMode mode, @NotNull BundleContext bundleContext, ResourceResolverTypeAdapter adapter) {
+        ResourceResolverFactory factory;
+        Object existingSnapshot = SNAPSHOTS.get(adapter.getClass());
+        SlingRepository repository;
+        if (existingSnapshot == null) {
+            repository = adapter.newSlingRepository();
+        } else {
+            repository = adapter.newSlingRepositoryFromSnapshot(existingSnapshot);
+        }
+        factory = ResourceResolverFactoryInitializer.setUp(
+                repository, bundleContext, existingSnapshot == null ? mode : NodeTypeMode.NOT_SUPPORTED);
+        if (existingSnapshot == null) {
+            Object newSnapshot = adapter.snapshot(repository);
+            if (newSnapshot != null) {
+                SNAPSHOTS.putIfAbsent(adapter.getClass(), newSnapshot);
+            }
         }
         return factory;
     }

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/spi/ResourceResolverTypeAdapter.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/spi/ResourceResolverTypeAdapter.java
@@ -50,4 +50,28 @@ public interface ResourceResolverTypeAdapter {
      */
     @Nullable
     SlingRepository newSlingRepository();
+
+    /**
+     * Make a snapshot of the current state of the given repository, or return
+     * null if snapshots are not supported.
+     * Returning non-null implies that calling {@link #newSlingRepositoryFromSnapshot(Object)}
+     * with the same object will succeed when called on objects of the same implementation type.
+     * The returned object must capture the whole state of the repository, and must not reflect
+     * any future changes made to the repository after this method returns.
+     * @param repository The repository to snapshot.
+     * @return A snapshot object.
+     */
+    @Nullable
+    default Object snapshot(SlingRepository repository) {
+        return null;
+    }
+
+    /**
+     * Get a SlingRepository instance based on a snapshot taken from another repository.
+     * @param snapshot A snapshot object, returned by an earlier call to {@link #snapshot(SlingRepository)}.
+     * @return A Sling repository instance.
+     */
+    default SlingRepository newSlingRepositoryFromSnapshot(Object snapshot) {
+        throw new UnsupportedOperationException("Snapshots not supported");
+    }
 }

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/spi/package-info.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/spi/package-info.java
@@ -19,5 +19,5 @@
 /**
  * SPI for hooking in alternative resource type adapter implementations.
  */
-@org.osgi.annotation.versioning.Version("1.0.1")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package org.apache.sling.testing.mock.sling.spi;

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/MockSlingTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/MockSlingTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.testing.mock.sling;
+
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.jcr.api.SlingRepository;
+import org.apache.sling.testing.mock.osgi.MockOsgi;
+import org.apache.sling.testing.mock.sling.spi.ResourceResolverTypeAdapter;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+
+import static org.junit.Assert.*;
+
+public class MockSlingTest {
+
+    private SlingRepository buildRepo(ResourceResolverTypeAdapter adapter) {
+        BundleContext context = MockOsgi.newBundleContext();
+        MockSling.buildFactoryFromRepository(NodeTypeMode.NOT_SUPPORTED, context, adapter);
+        return context.getService(context.getServiceReference(SlingRepository.class));
+    }
+
+    @Test
+    public void testAdapterDoesNotSupportSnapshots() {
+        ResourceResolverTypeAdapter snapshotUnawareAdapter = new ResourceResolverTypeAdapter() {
+            @Override
+            public @Nullable ResourceResolverFactory newResourceResolverFactory() {
+                return null;
+            }
+
+            @Override
+            public SlingRepository newSlingRepository() {
+                return new MockJcrSlingRepository();
+            }
+        };
+
+        SlingRepository repo1 = buildRepo(snapshotUnawareAdapter);
+        SlingRepository repo2 = buildRepo(snapshotUnawareAdapter);
+
+        assertNotNull(repo1);
+        assertNotNull(repo2);
+        assertNotSame(repo2, repo1);
+    }
+
+    @Test
+    public void testAdapterSupportsSnapshots() {
+        SlingRepository freshRepo = new MockJcrSlingRepository();
+        SlingRepository snapshotRepo = new MockJcrSlingRepository();
+        ResourceResolverTypeAdapter snapshotAwareAdapter = new ResourceResolverTypeAdapter() {
+            @Override
+            public @Nullable ResourceResolverFactory newResourceResolverFactory() {
+                return null;
+            }
+
+            @Override
+            public SlingRepository newSlingRepository() {
+                return freshRepo;
+            }
+
+            @Override
+            public Object snapshot(SlingRepository repository) {
+                return "dummy";
+            }
+
+            @Override
+            public SlingRepository newSlingRepositoryFromSnapshot(Object snapshot) {
+                return snapshotRepo;
+            }
+        };
+
+        SlingRepository repo1 = buildRepo(snapshotAwareAdapter);
+        SlingRepository repo2 = buildRepo(snapshotAwareAdapter);
+
+        assertSame(freshRepo, repo1);
+        assertSame(snapshotRepo, repo2);
+    }
+}


### PR DESCRIPTION
Allow resource resolver types to save the state of an already initialized repository and restore it when creating future repositories. Only Oak can meaningfully support this right now, as it's already built on immutable node state objects.