### PR TITLE
SLING-12880 Update Sling Mocks to Sling API 3

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.testing.sling-mock.parent</artifactId>
-        <version>3.5.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -246,6 +246,16 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.http.wrappers</artifactId>
             <scope>compile</scope>
         </dependency>
 

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/MockAdapterManagerImpl.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/MockAdapterManagerImpl.java
@@ -87,8 +87,7 @@ public class MockAdapterManagerImpl implements AdapterManager {
      * the manager has been activated. These bound services will be accessed as
      * soon as the manager is being activated.
      */
-    private final List<ServiceReference<AdapterFactory>> boundAdapterFactories =
-            new LinkedList<ServiceReference<AdapterFactory>>();
+    private final List<ServiceReference<AdapterFactory>> boundAdapterFactories = new LinkedList<>();
 
     /**
      * A map of {@link AdapterFactoryDescriptorMap} instances. The map is
@@ -98,8 +97,7 @@ public class MockAdapterManagerImpl implements AdapterManager {
      *
      * @see AdapterFactoryDescriptorMap
      */
-    private final Map<String, AdapterFactoryDescriptorMap> descriptors =
-            new HashMap<String, AdapterFactoryDescriptorMap>();
+    private final Map<String, AdapterFactoryDescriptorMap> descriptors = new HashMap<>();
 
     /**
      * Matrix of {@link AdapterFactoryDescriptor} instances primarily indexed by the fully
@@ -111,7 +109,7 @@ public class MockAdapterManagerImpl implements AdapterManager {
      * whenever an adapter factory is registered on unregistered.
      */
     private final ConcurrentMap<String, Map<String, List<AdapterFactoryDescriptor>>> factoryCache =
-            new ConcurrentHashMap<String, Map<String, List<AdapterFactoryDescriptor>>>();
+            new ConcurrentHashMap<>();
 
     // DISABLED IN THIS COPY OF CLASS
     /*
@@ -138,7 +136,7 @@ public class MockAdapterManagerImpl implements AdapterManager {
         // get the factory for the target type
         final List<AdapterFactoryDescriptor> descList = factories.get(type.getName());
 
-        if (descList != null && descList.size() > 0) {
+        if (descList != null && !descList.isEmpty()) {
             for (AdapterFactoryDescriptor desc : descList) {
                 final AdapterFactory factory = desc == null ? null : desc.getFactory();
 
@@ -174,7 +172,7 @@ public class MockAdapterManagerImpl implements AdapterManager {
         // register all adapter factories bound before activation
         final List<ServiceReference<AdapterFactory>> refs;
         synchronized (this.boundAdapterFactories) {
-            refs = new ArrayList<ServiceReference<AdapterFactory>>(this.boundAdapterFactories);
+            refs = new ArrayList<>(this.boundAdapterFactories);
             boundAdapterFactories.clear();
         }
         for (final ServiceReference<AdapterFactory> reference : refs) {
@@ -219,7 +217,7 @@ public class MockAdapterManagerImpl implements AdapterManager {
      * Unbind a adapter factory.
      * @param reference Service reference
      */
-    protected void unbindAdapterFactory(final ServiceReference reference) {
+    protected void unbindAdapterFactory(final ServiceReference<AdapterFactory> reference) {
         unregisterAdapterFactory(reference);
     }
 
@@ -249,7 +247,7 @@ public class MockAdapterManagerImpl implements AdapterManager {
      * Unregisters the {@link AdapterFactory} referred to by the service
      * <code>reference</code> from the registry.
      */
-    @SuppressWarnings("null")
+    @SuppressWarnings({"null", "deprecation"})
     private void registerAdapterFactory(
             final ComponentContext context, final ServiceReference<AdapterFactory> reference) {
         final String[] adaptables = PropertiesUtil.toStringArray(reference.getProperty(ADAPTABLE_CLASSES));
@@ -294,7 +292,7 @@ public class MockAdapterManagerImpl implements AdapterManager {
         this.factoryCache.clear();
 
         // register adaption
-        final Dictionary<String, Object> props = new Hashtable<String, Object>();
+        final Dictionary<String, Object> props = new Hashtable<>();
         props.put(SlingConstants.PROPERTY_ADAPTABLE_CLASSES, adaptables);
         props.put(SlingConstants.PROPERTY_ADAPTER_CLASSES, adapters);
 
@@ -340,7 +338,8 @@ public class MockAdapterManagerImpl implements AdapterManager {
      * Unregisters the {@link AdapterFactory} referred to by the service
      * <code>reference</code> from the registry.
      */
-    private void unregisterAdapterFactory(final ServiceReference reference) {
+    @SuppressWarnings("deprecation")
+    private void unregisterAdapterFactory(final ServiceReference<AdapterFactory> reference) {
         synchronized (this.boundAdapterFactories) {
             boundAdapterFactories.remove(reference);
         }
@@ -434,7 +433,7 @@ public class MockAdapterManagerImpl implements AdapterManager {
      *         <code>clazz</code>.
      */
     private Map<String, List<AdapterFactoryDescriptor>> createAdapterFactoryMap(final Class<?> clazz) {
-        final Map<String, List<AdapterFactoryDescriptor>> afm = new HashMap<String, List<AdapterFactoryDescriptor>>();
+        final Map<String, List<AdapterFactoryDescriptor>> afm = new HashMap<>();
 
         // AdapterFactories for this class
         AdapterFactoryDescriptorMap afdMap = null;
@@ -444,7 +443,7 @@ public class MockAdapterManagerImpl implements AdapterManager {
         if (afdMap != null) {
             final List<AdapterFactoryDescriptor> afdSet;
             synchronized (afdMap) {
-                afdSet = new ArrayList<AdapterFactoryDescriptor>(afdMap.values());
+                afdSet = new ArrayList<>(afdMap.values());
             }
             for (final AdapterFactoryDescriptor afd : afdSet) {
                 final String[] adapters = afd.getAdapters();
@@ -452,7 +451,7 @@ public class MockAdapterManagerImpl implements AdapterManager {
                     // to handle service ranking, we add to the end of the list or create a new list
                     List<AdapterFactoryDescriptor> factoryDescriptors = afm.get(adapter);
                     if (factoryDescriptors == null) {
-                        factoryDescriptors = new ArrayList<AdapterFactoryDescriptor>();
+                        factoryDescriptors = new ArrayList<>();
                         afm.put(adapter, factoryDescriptors);
                     }
                     factoryDescriptors.add(afd);
@@ -498,7 +497,7 @@ public class MockAdapterManagerImpl implements AdapterManager {
             List<AdapterFactoryDescriptor> factoryDescriptors = dest.get(entry.getKey());
 
             if (factoryDescriptors == null) {
-                factoryDescriptors = new ArrayList<AdapterFactoryDescriptor>();
+                factoryDescriptors = new ArrayList<>();
                 dest.put(entry.getKey(), factoryDescriptors);
             }
             for (AdapterFactoryDescriptor descriptor : entry.getValue()) {

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/MockResourceBundleProvider.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/MockResourceBundleProvider.java
@@ -97,8 +97,7 @@ public final class MockResourceBundleProvider implements ResourceBundleProvider 
         public boolean equals(Object obj) {
             if (obj == this) {
                 return true;
-            } else if (obj instanceof Key) {
-                Key other = (Key) obj;
+            } else if (obj instanceof Key other) {
                 return equals(this.baseName, other.baseName) && equals(this.locale, other.locale);
             }
 

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/MockSlingScriptHelper.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/MockSlingScriptHelper.java
@@ -19,15 +19,19 @@
 package org.apache.sling.testing.mock.sling;
 
 import java.lang.reflect.Array;
+import java.util.Collection;
 
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.request.RequestDispatcherOptions;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.InvalidServiceFilterSyntaxException;
 import org.apache.sling.api.scripting.SlingScript;
 import org.apache.sling.api.scripting.SlingScriptHelper;
+import org.apache.sling.api.wrappers.JavaxToJakartaRequestWrapper;
+import org.apache.sling.api.wrappers.JavaxToJakartaResponseWrapper;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletRequest;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletResponse;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
@@ -39,8 +43,21 @@ import org.osgi.framework.ServiceReference;
  */
 public final class MockSlingScriptHelper implements SlingScriptHelper {
 
-    private final @NotNull SlingHttpServletRequest request;
-    private final @NotNull SlingHttpServletResponse response;
+    private final @NotNull SlingJakartaHttpServletRequest jakartaRequest;
+    private final @NotNull SlingJakartaHttpServletResponse jakartaResponse;
+
+    /**
+     * @deprecated Use jakartaRequest instead.
+     */
+    @Deprecated(since = "4.1.0")
+    private final @NotNull org.apache.sling.api.SlingHttpServletRequest request;
+
+    /**
+     * @deprecated Use jakartaResponse instead.
+     */
+    @Deprecated(since = "4.1.0")
+    private final @NotNull org.apache.sling.api.SlingHttpServletResponse response;
+
     private final @NotNull BundleContext bundleContext;
     private SlingScript script;
 
@@ -48,32 +65,91 @@ public final class MockSlingScriptHelper implements SlingScriptHelper {
      * @param request Sling HTTP servlet request
      * @param response Sling HTTP servlet response
      * @param bundleContext OSGi bundle context
+     *
+     * @deprecated Use {@link MockSlingScriptHelper#MockSlingScriptHelper(SlingJakartaHttpServletRequest, SlingJakartaHttpServletResponse, BundleContext)} instead.
      */
+    @Deprecated(since = "4.1.0")
     public MockSlingScriptHelper(
-            @NotNull final SlingHttpServletRequest request,
-            @NotNull final SlingHttpServletResponse response,
+            @NotNull final org.apache.sling.api.SlingHttpServletRequest request,
+            @NotNull final org.apache.sling.api.SlingHttpServletResponse response,
             @NotNull final BundleContext bundleContext) {
+        this.jakartaRequest = toJakartaRequest(request);
+        this.jakartaResponse = toJakartaResponse(response);
         this.request = request;
         this.response = response;
         this.bundleContext = bundleContext;
     }
 
-    @Override
-    public @NotNull SlingHttpServletRequest getRequest() {
-        return this.request;
+    @SuppressWarnings("deprecation")
+    private SlingJakartaHttpServletRequest toJakartaRequest(org.apache.sling.api.SlingHttpServletRequest request) {
+        if (request instanceof org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest mshsr) {
+            return (SlingJakartaHttpServletRequest) mshsr.getRequest();
+        } else {
+            return JavaxToJakartaRequestWrapper.toJakartaRequest(request);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private SlingJakartaHttpServletResponse toJakartaResponse(org.apache.sling.api.SlingHttpServletResponse response) {
+        if (response instanceof org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse mshsr) {
+            return (SlingJakartaHttpServletResponse) mshsr.getResponse();
+        } else {
+            return JavaxToJakartaResponseWrapper.toJakartaResponse(response);
+        }
+    }
+
+    /**
+     * @param request Sling HTTP servlet request
+     * @param response Sling HTTP servlet response
+     * @param bundleContext OSGi bundle context
+     */
+    @SuppressWarnings("deprecation")
+    public MockSlingScriptHelper(
+            @NotNull final SlingJakartaHttpServletRequest request,
+            @NotNull final SlingJakartaHttpServletResponse response,
+            @NotNull final BundleContext bundleContext) {
+        this.jakartaRequest = request;
+        this.jakartaResponse = response;
+        this.request = new org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest(
+                (MockSlingJakartaHttpServletRequest) this.jakartaRequest);
+        this.response = new org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse(
+                (MockSlingJakartaHttpServletResponse) this.jakartaResponse);
+        this.bundleContext = bundleContext;
     }
 
     @Override
-    public @NotNull SlingHttpServletResponse getResponse() {
+    public @NotNull SlingJakartaHttpServletRequest getJakartaRequest() {
+        return this.jakartaRequest;
+    }
+
+    @Override
+    public @NotNull SlingJakartaHttpServletResponse getJakartaResponse() {
+        return this.jakartaResponse;
+    }
+
+    /**
+     * @deprecated Use {@link #getJakartaRequest()} instead.
+     */
+    @Deprecated(since = "4.1.0")
+    @Override
+    public @NotNull org.apache.sling.api.SlingHttpServletRequest getRequest() {
+        return this.request;
+    }
+
+    /**
+     * @deprecated Use {@link #getJakartaResponse()} instead.
+     */
+    @Deprecated(since = "4.1.0")
+    @Override
+    public @NotNull org.apache.sling.api.SlingHttpServletResponse getResponse() {
         return this.response;
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public @Nullable <ServiceType> ServiceType getService(@NotNull final Class<ServiceType> serviceType) {
-        ServiceReference serviceReference = this.bundleContext.getServiceReference(serviceType.getName());
+    public @Nullable <T> T getService(@NotNull final Class<T> serviceType) {
+        ServiceReference<T> serviceReference = this.bundleContext.getServiceReference(serviceType);
         if (serviceReference != null) {
-            return (ServiceType) this.bundleContext.getService(serviceReference);
+            return this.bundleContext.getService(serviceReference);
         } else {
             return null;
         }
@@ -81,20 +157,13 @@ public final class MockSlingScriptHelper implements SlingScriptHelper {
 
     @Override
     @SuppressWarnings("unchecked")
-    public @Nullable <ServiceType> ServiceType[] getServices(
-            @NotNull final Class<ServiceType> serviceType, final String filter) {
+    public @Nullable <T> T[] getServices(@NotNull final Class<T> serviceType, final String filter) {
         try {
-            ServiceReference[] serviceReferences =
-                    this.bundleContext.getServiceReferences(serviceType.getName(), filter);
-            if (serviceReferences != null) {
-                ServiceType[] services = (ServiceType[]) Array.newInstance(serviceType, serviceReferences.length);
-                for (int i = 0; i < serviceReferences.length; i++) {
-                    services[i] = (ServiceType) this.bundleContext.getService(serviceReferences[i]);
-                }
-                return services;
-            } else {
-                return (ServiceType[]) ArrayUtils.EMPTY_OBJECT_ARRAY;
-            }
+            Collection<ServiceReference<T>> serviceReferences =
+                    this.bundleContext.getServiceReferences(serviceType, filter);
+            return serviceReferences.stream()
+                    .map(this.bundleContext::getService)
+                    .toArray(size -> (T[]) Array.newInstance(serviceType, size));
         } catch (InvalidSyntaxException ex) {
             throw new InvalidServiceFilterSyntaxException(filter, ex.getMessage(), ex);
         }

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/NodeTypeDefinitionScanner.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/NodeTypeDefinitionScanner.java
@@ -128,8 +128,8 @@ public final class NodeTypeDefinitionScanner {
                     continue;
                 }
                 Reader reader = new InputStreamReader(is);
-                CompactNodeTypeDefReader<NodeTypeTemplate, NamespaceRegistry> cndReader = new CompactNodeTypeDefReader<
-                        NodeTypeTemplate, NamespaceRegistry>(reader, nodeTypeResource, factory);
+                CompactNodeTypeDefReader<NodeTypeTemplate, NamespaceRegistry> cndReader =
+                        new CompactNodeTypeDefReader<>(reader, nodeTypeResource, factory);
                 NamespaceRegistry mapping = cndReader.getNamespaceMapping();
                 for (int i = 0; i < mapping.getURIs().length; i++) {
                     String uri = mapping.getURIs()[i];
@@ -204,7 +204,7 @@ public final class NodeTypeDefinitionScanner {
      * @return List of node type definition class paths
      */
     private static List<String> findeNodeTypeDefinitions() {
-        return new ArrayList<String>(ManifestScanner.getValues("Sling-Nodetypes"));
+        return new ArrayList<>(ManifestScanner.getValues("Sling-Nodetypes"));
     }
 
     /**

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapper.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapper.java
@@ -81,7 +81,7 @@ class ThreadsafeMockAdapterManagerWrapper implements AdapterManager {
 
             // register adapter manager
             MockAdapterManagerImpl adapterManagerImpl = new MockAdapterManagerImpl();
-            Dictionary<String, Object> properties = new Hashtable<String, Object>();
+            Dictionary<String, Object> properties = new Hashtable<>();
             MockOsgi.injectServices(adapterManagerImpl, bundleContext);
             MockOsgi.activate(adapterManagerImpl, bundleContext, properties);
             bundleContext.registerService(AdapterManager.class.getName(), adapterManagerImpl, properties);

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/builder/ContentBuilder.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/builder/ContentBuilder.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
@@ -111,8 +112,8 @@ public class ContentBuilder {
     private Map<String, Map<String, Object>> getChildMaps(Map<String, Object> properties) {
         Map<String, Map<String, Object>> result = new LinkedHashMap<>();
         for (Map.Entry<String, Object> entry : properties.entrySet()) {
-            if (entry.getValue() instanceof Map) {
-                result.put(entry.getKey(), (Map) entry.getValue());
+            if (entry.getValue() instanceof @SuppressWarnings("rawtypes") Map entryValue) {
+                result.put(entry.getKey(), entryValue);
             }
         }
         return result;
@@ -172,7 +173,7 @@ public class ContentBuilder {
      */
     @SuppressWarnings("null")
     protected final @NotNull Resource ensureResourceExists(@NotNull String path) {
-        if (StringUtils.isEmpty(path) || StringUtils.equals(path, "/")) {
+        if (StringUtils.isEmpty(path) || Strings.CS.equals(path, "/")) {
             return resourceResolver.getResource("/");
         }
         Resource resource = resourceResolver.getResource(path);

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/builder/ImmutableValueMap.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/builder/ImmutableValueMap.java
@@ -323,8 +323,8 @@ public final class ImmutableValueMap implements ValueMap {
      * @throws NullPointerException if any key or value in {@code map} is null
      */
     public static @NotNull ImmutableValueMap copyOf(@NotNull Map<String, Object> map) {
-        if (map instanceof ValueMap) {
-            return new ImmutableValueMap((ValueMap) map);
+        if (map instanceof ValueMap valueMap) {
+            return new ImmutableValueMap(valueMap);
         } else {
             return new ImmutableValueMap(map);
         }

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/context/MockSlingBindings.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/context/MockSlingBindings.java
@@ -22,7 +22,7 @@ import javax.jcr.Node;
 import javax.jcr.Session;
 import javax.script.Bindings;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.LazyBindings;
 import org.apache.sling.api.scripting.SlingBindings;
@@ -61,8 +61,8 @@ class MockSlingBindings extends SlingBindings implements EventHandler {
         if (this.context == null) {
             return null;
         }
-        if (key instanceof String) {
-            Object result = context.resolveSlingBindingProperty((String) key, context.request());
+        if (key instanceof String keyString) {
+            Object result = context.resolveSlingBindingProperty(keyString, context.jakartaRequest());
             if (result != null) {
                 return result;
             }
@@ -95,40 +95,47 @@ class MockSlingBindings extends SlingBindings implements EventHandler {
         populateFromBindingsValuesProvider();
     }
 
+    @SuppressWarnings("deprecation")
     static @Nullable Object resolveSlingBindingProperty(@NotNull SlingContextImpl context, @NotNull String property) {
 
         // -- Sling --
-        if (StringUtils.equals(property, RESOLVER)) {
+        if (Strings.CS.equals(property, RESOLVER)) {
             return context.resourceResolver();
         }
-        if (StringUtils.equals(property, RESOURCE)) {
+        if (Strings.CS.equals(property, RESOURCE)) {
             return context.currentResource();
         }
-        if (StringUtils.equals(property, REQUEST)) {
+        if (Strings.CS.equals(property, REQUEST)) {
             return context.request();
         }
-        if (StringUtils.equals(property, RESPONSE)) {
+        if (Strings.CS.equals(property, RESPONSE)) {
             return context.response();
         }
-        if (StringUtils.equals(property, SLING)) {
+        if (Strings.CS.equals(property, JAKARTA_REQUEST)) {
+            return context.jakartaRequest();
+        }
+        if (Strings.CS.equals(property, JAKARTA_RESPONSE)) {
+            return context.jakartaResponse();
+        }
+        if (Strings.CS.equals(property, SLING)) {
             return context.slingScriptHelper();
         }
-        if (StringUtils.equals(property, READER)) {
-            return context.request().getReader();
+        if (Strings.CS.equals(property, READER)) {
+            return context.jakartaRequest().getReader();
         }
-        if (StringUtils.equals(property, OUT)) {
-            return context.response().getWriter();
+        if (Strings.CS.equals(property, OUT)) {
+            return context.jakartaResponse().getWriter();
         }
 
         // -- JCR --
         // this emulates behavior of org.apache.sling.jcr.resource.internal.scripting.JcrObjectsBindingsValuesProvider
-        if (StringUtils.equals(property, PROP_CURRENT_NODE)) {
+        if (Strings.CS.equals(property, PROP_CURRENT_NODE)) {
             Resource resource = context.currentResource();
             if (resource != null) {
                 return resource.adaptTo(Node.class);
             }
         }
-        if (StringUtils.equals(property, PROP_CURRENT_SESSION)) {
+        if (Strings.CS.equals(property, PROP_CURRENT_SESSION)) {
             return context.resourceResolver().adaptTo(Session.class);
         }
 

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/context/ModelAdapterFactoryUtil.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/context/ModelAdapterFactoryUtil.java
@@ -63,10 +63,8 @@ final class ModelAdapterFactoryUtil {
     private static final @NotNull String @NotNull [] MODELS_PACKAGES_FROM_MANIFEST;
     private static final @NotNull String @NotNull [] MODELS_CLASSES_FROM_MANIFEST;
 
-    private static final @NotNull ConcurrentMap<String, List<URL>> MODEL_URLS_FOR_PACKAGES =
-            new ConcurrentHashMap<String, List<URL>>();
-    private static final @NotNull ConcurrentMap<String, List<URL>> MODEL_URLS_FOR_CLASSES =
-            new ConcurrentHashMap<String, List<URL>>();
+    private static final @NotNull ConcurrentMap<String, List<URL>> MODEL_URLS_FOR_PACKAGES = new ConcurrentHashMap<>();
+    private static final @NotNull ConcurrentMap<String, List<URL>> MODEL_URLS_FOR_CLASSES = new ConcurrentHashMap<>();
 
     static {
         // scan classpath for models bundle header entries only once
@@ -112,7 +110,7 @@ final class ModelAdapterFactoryUtil {
      * @param bundleContext Bundle context
      * @param classNames Java class names
      */
-    public static void addModelsForClasses(@NotNull BundleContext bundleContext, @NotNull Class @NotNull ... classes) {
+    public static void addModelsForClasses(@NotNull BundleContext bundleContext, @NotNull Class<?>... classes) {
         String[] classNames = new String[classes.length];
         for (int i = 0; i < classes.length; i++) {
             classNames[i] = classes[i].getName();
@@ -141,7 +139,7 @@ final class ModelAdapterFactoryUtil {
     private static Collection<URL> getModelClassUrlsForPackages(String packageNames) {
         List<URL> urls = MODEL_URLS_FOR_PACKAGES.get(packageNames);
         if (urls == null) {
-            urls = new ArrayList<URL>();
+            urls = new ArrayList<>();
             // add "." to each package name because it's a prefix, not a package name
             ConfigurationBuilder reflectionsConfig = new ConfigurationBuilder();
             Stream.of(StringUtils.split(packageNames, ","))
@@ -164,7 +162,7 @@ final class ModelAdapterFactoryUtil {
     private static Collection<URL> getModelClassUrlsForClasses(String classNames) {
         List<URL> urls = MODEL_URLS_FOR_CLASSES.get(classNames);
         if (urls == null) {
-            urls = new ArrayList<URL>();
+            urls = new ArrayList<>();
             String[] packageNameArray = StringUtils.split(classNames, ",");
             for (String className : packageNameArray) {
                 try {
@@ -181,7 +179,7 @@ final class ModelAdapterFactoryUtil {
         return urls;
     }
 
-    private static URL classToUrl(Class clazz) {
+    private static URL classToUrl(Class<?> clazz) {
         try {
             return new URL("file:/" + clazz.getName().replace('.', '/') + ".class");
         } catch (MalformedURLException ex) {
@@ -220,14 +218,14 @@ final class ModelAdapterFactoryUtil {
 
         @Override
         public Dictionary<String, String> getHeaders() {
-            Dictionary<String, String> headers = new Hashtable<String, String>();
+            Dictionary<String, String> headers = new Hashtable<>();
             headers.put(PACKAGE_HEADER, MAGIC_STRING);
             return headers;
         }
 
         @Override
         public Enumeration<URL> findEntries(String path, String filePattern, boolean recurse) {
-            Vector<URL> urls = new Vector<URL>(); // NOPMD
+            Vector<URL> urls = new Vector<>(); // NOPMD
             if (packageNames != null) {
                 urls.addAll(getModelClassUrlsForPackages(packageNames));
             }

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/context/package-info.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/context/package-info.java
@@ -19,5 +19,5 @@
 /**
  * Sling context implementation for unit tests.
  */
-@org.osgi.annotation.versioning.Version("4.0.0")
+@org.osgi.annotation.versioning.Version("4.1.0")
 package org.apache.sling.testing.mock.sling.context;

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/loader/ContentLoader.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/loader/ContentLoader.java
@@ -337,7 +337,7 @@ public final class ContentLoader {
         if (parentResource == null) {
             parentResource = createResourceHierarchy(parentPath);
         }
-        Map<String, Object> props = new HashMap<String, Object>();
+        Map<String, Object> props = new HashMap<>();
         props.put(JcrConstants.JCR_PRIMARYTYPE, JcrConstants.NT_UNSTRUCTURED);
         try {
             return resourceResolver.create(parentResource, ResourceUtil.getName(path), props);

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/loader/LoaderContentHandler.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/loader/LoaderContentHandler.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.PersistenceException;
@@ -51,7 +52,7 @@ final class LoaderContentHandler implements ContentHandler {
     @Override
     public void resource(String path, Map<String, Object> properties) {
         String fullPath = rootPath;
-        if (!StringUtils.equals(path, "/")) {
+        if (!Strings.CS.equals(path, "/")) {
             fullPath += path;
         }
         String parentPath = ResourceUtil.getParent(fullPath);
@@ -79,13 +80,13 @@ final class LoaderContentHandler implements ContentHandler {
         // collect all properties first
         boolean hasJcrData = false;
         String referencedNodePath = null;
-        Map<String, Object> props = new HashMap<String, Object>();
+        Map<String, Object> props = new HashMap<>();
         if (content != null) {
             for (Map.Entry<String, Object> entry : content.entrySet()) {
                 final String name = entry.getKey();
-                if (StringUtils.equals(name, JCR_DATA_PLACEHOLDER)) {
+                if (Strings.CS.equals(name, JCR_DATA_PLACEHOLDER)) {
                     hasJcrData = true;
-                } else if (StringUtils.equals(name, JCR_REFERENCE_PLACEHOLDER)) {
+                } else if (Strings.CS.equals(name, JCR_REFERENCE_PLACEHOLDER)) {
                     referencedNodePath = (String) entry.getValue();
                 } else {
                     props.put(name, entry.getValue());

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/package-info.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/package-info.java
@@ -19,5 +19,5 @@
 /**
  * Mock implementation of selected Sling APIs.
  */
-@org.osgi.annotation.versioning.Version("4.0.0")
+@org.osgi.annotation.versioning.Version("4.1.0")
 package org.apache.sling.testing.mock.sling;

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockHttpSession.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockHttpSession.java
@@ -18,12 +18,22 @@
  */
 package org.apache.sling.testing.mock.sling.servlet;
 
+import org.apache.sling.servlethelpers.MockJakartaServletContext;
+
 /**
  * Mock {@link javax.servlet.http.HttpSession} implementation.
+ *
+ * @deprecated Use {@link MockJakartaHttpSession} instead.
  */
+@Deprecated(since = "3.2.0")
 public final class MockHttpSession extends org.apache.sling.servlethelpers.MockHttpSession {
 
+    public MockHttpSession(org.apache.sling.servlethelpers.MockJakartaHttpSession wrappedSession) {
+        super(wrappedSession);
+    }
+
+    @Override
     protected MockServletContext newMockServletContext() {
-        return new MockServletContext();
+        return new MockServletContext(new MockJakartaServletContext());
     }
 }

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockJakartaHttpSession.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockJakartaHttpSession.java
@@ -19,17 +19,12 @@
 package org.apache.sling.testing.mock.sling.servlet;
 
 /**
- * Mock {@link javax.servlet.ServletContext} implementation.
- *
- * @deprecated Use {@link MockJakartaServletContext} instead.
+ * Mock {@link jakarta.servlet.http.HttpSession} implementation.
  */
-@Deprecated(since = "3.2.0")
-public final class MockServletContext extends org.apache.sling.servlethelpers.MockServletContext {
+public final class MockJakartaHttpSession extends org.apache.sling.servlethelpers.MockJakartaHttpSession {
 
-    public MockServletContext(org.apache.sling.servlethelpers.MockJakartaServletContext wrappedServletContext) {
-        super(wrappedServletContext);
+    @Override
+    protected MockJakartaServletContext newMockServletContext() {
+        return new MockJakartaServletContext();
     }
-
-    // inherit from superclass
-
 }

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockJakartaRequestDispatcherFactory.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockJakartaRequestDispatcherFactory.java
@@ -19,16 +19,11 @@
 package org.apache.sling.testing.mock.sling.servlet;
 
 /**
- * Mock {@link javax.servlet.ServletContext} implementation.
- *
- * @deprecated Use {@link MockJakartaServletContext} instead.
+ * Interface to create a mock {@link jakarta.servlet.RequestDispatcher} when calling the getRequestDispatcher methods
+ * on {@link MockSlingJakartaHttpServletRequest} instances.
  */
-@Deprecated(since = "3.2.0")
-public final class MockServletContext extends org.apache.sling.servlethelpers.MockServletContext {
-
-    public MockServletContext(org.apache.sling.servlethelpers.MockJakartaServletContext wrappedServletContext) {
-        super(wrappedServletContext);
-    }
+public interface MockJakartaRequestDispatcherFactory
+        extends org.apache.sling.servlethelpers.MockJakartaRequestDispatcherFactory {
 
     // inherit from superclass
 

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockJakartaServletContext.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockJakartaServletContext.java
@@ -19,16 +19,9 @@
 package org.apache.sling.testing.mock.sling.servlet;
 
 /**
- * Mock {@link javax.servlet.ServletContext} implementation.
- *
- * @deprecated Use {@link MockJakartaServletContext} instead.
+ * Mock {@link jakarta.servlet.ServletContext} implementation.
  */
-@Deprecated(since = "3.2.0")
-public final class MockServletContext extends org.apache.sling.servlethelpers.MockServletContext {
-
-    public MockServletContext(org.apache.sling.servlethelpers.MockJakartaServletContext wrappedServletContext) {
-        super(wrappedServletContext);
-    }
+public final class MockJakartaServletContext extends org.apache.sling.servlethelpers.MockJakartaServletContext {
 
     // inherit from superclass
 

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockRequestDispatcherFactory.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockRequestDispatcherFactory.java
@@ -21,7 +21,10 @@ package org.apache.sling.testing.mock.sling.servlet;
 /**
  * Interface to create a mock {@link javax.servlet.RequestDispatcher} when calling the getRequestDispatcher methods
  * on {@link MockSlingHttpServletRequest} instances.
+ *
+ * @deprecated Use {@link MockJakartaRequestDispatcherFactory} instead.
  */
+@Deprecated(since = "3.2.0")
 public interface MockRequestDispatcherFactory extends org.apache.sling.servlethelpers.MockRequestDispatcherFactory {
 
     // inherit from superclass

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockSlingHttpServletRequest.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockSlingHttpServletRequest.java
@@ -18,64 +18,40 @@
  */
 package org.apache.sling.testing.mock.sling.servlet;
 
-import java.util.Locale;
-import java.util.ResourceBundle;
-
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.i18n.ResourceBundleProvider;
 import org.apache.sling.testing.mock.sling.MockSling;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceReference;
 
 /**
  * Mock {@link org.apache.sling.api.SlingHttpServletRequest} implementation.
+ *
+ * @deprecated Use {@link MockSlingJakartaHttpServletRequest} instead.
  */
+@Deprecated(since = "3.2.0")
 public class MockSlingHttpServletRequest extends org.apache.sling.servlethelpers.MockSlingHttpServletRequest {
-
-    private final BundleContext bundleContext;
 
     /**
      * Instantiate with default resource resolver
      * @param bundleContext Bundle context
      */
     public MockSlingHttpServletRequest(@NotNull BundleContext bundleContext) {
-        this(MockSling.newResourceResolver(bundleContext), bundleContext);
+        this(new MockSlingJakartaHttpServletRequest(MockSling.newResourceResolver(bundleContext), bundleContext));
     }
 
     /**
-     * @param resourceResolver Resource resolver
-     * @param bundleContext Bundle context
+     * @param jakartaRequest the jakarta request to wrap
      */
-    public MockSlingHttpServletRequest(
-            @NotNull ResourceResolver resourceResolver, @NotNull BundleContext bundleContext) {
-        super(resourceResolver);
-        this.bundleContext = bundleContext;
+    public MockSlingHttpServletRequest(@NotNull MockSlingJakartaHttpServletRequest jakartaRequest) {
+        super(jakartaRequest);
     }
 
+    @Override
     protected @NotNull MockRequestPathInfo newMockRequestPathInfo() {
         return new MockRequestPathInfo(getResourceResolver());
     }
 
-    protected @NotNull MockHttpSession newMockHttpSession() {
-        return new MockHttpSession();
-    }
-
     @Override
-    @SuppressWarnings("null")
-    public ResourceBundle getResourceBundle(String baseName, Locale locale) {
-        // check of ResourceBundleProvider is registered in mock OSGI context
-        ResourceBundle resourceBundle = null;
-        ServiceReference<ResourceBundleProvider> serviceReference =
-                bundleContext.getServiceReference(ResourceBundleProvider.class);
-        if (serviceReference != null) {
-            ResourceBundleProvider provider = (ResourceBundleProvider) bundleContext.getService(serviceReference);
-            resourceBundle = provider.getResourceBundle(baseName, locale);
-        }
-        // if no ResourceBundleProvider exists return empty bundle
-        if (resourceBundle == null) {
-            resourceBundle = EMPTY_RESOURCE_BUNDLE;
-        }
-        return resourceBundle;
+    protected @NotNull MockHttpSession newMockHttpSession() {
+        return new MockHttpSession(new MockJakartaHttpSession());
     }
 }

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockSlingHttpServletResponse.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockSlingHttpServletResponse.java
@@ -20,8 +20,15 @@ package org.apache.sling.testing.mock.sling.servlet;
 
 /**
  * Mock {@link org.apache.sling.api.SlingHttpServletResponse} implementation.
+ *
+ * @deprecated Use {@link MockSlingJakartaHttpServletResponse} instead.
  */
+@Deprecated(since = "3.2.0")
 public class MockSlingHttpServletResponse extends org.apache.sling.servlethelpers.MockSlingHttpServletResponse {
+
+    public MockSlingHttpServletResponse(MockSlingJakartaHttpServletResponse wrappedResponse) {
+        super(wrappedResponse);
+    }
 
     // inherit from superclass
 

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockSlingJakartaHttpServletResponse.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/MockSlingJakartaHttpServletResponse.java
@@ -19,16 +19,10 @@
 package org.apache.sling.testing.mock.sling.servlet;
 
 /**
- * Mock {@link javax.servlet.ServletContext} implementation.
- *
- * @deprecated Use {@link MockJakartaServletContext} instead.
+ * Mock {@link org.apache.sling.api.SlingJakartaHttpServletResponse} implementation.
  */
-@Deprecated(since = "3.2.0")
-public final class MockServletContext extends org.apache.sling.servlethelpers.MockServletContext {
-
-    public MockServletContext(org.apache.sling.servlethelpers.MockJakartaServletContext wrappedServletContext) {
-        super(wrappedServletContext);
-    }
+public class MockSlingJakartaHttpServletResponse
+        extends org.apache.sling.servlethelpers.MockSlingJakartaHttpServletResponse {
 
     // inherit from superclass
 

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/package-info.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/servlet/package-info.java
@@ -19,5 +19,5 @@
 /**
  * Mock implementation of selected Servlet-related Sling APIs.
  */
-@org.osgi.annotation.versioning.Version("3.1")
+@org.osgi.annotation.versioning.Version("4.0.0")
 package org.apache.sling.testing.mock.sling.servlet;

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/MockResourceBundleProviderTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/MockResourceBundleProviderTest.java
@@ -39,14 +39,14 @@ public class MockResourceBundleProviderTest {
 
     @Test
     public void testGetResourceBundleFromRequest() {
-        ResourceBundle bundle = context.request().getResourceBundle(Locale.CANADA_FRENCH);
+        ResourceBundle bundle = context.jakartaRequest().getResourceBundle(Locale.CANADA_FRENCH);
         assertEquals(Locale.CANADA_FRENCH, bundle.getLocale());
         assertNull(((MockResourceBundle) bundle).getBaseName());
     }
 
     @Test
     public void testGetResourceBundleFromRequestWithBaseName() {
-        ResourceBundle bundle = context.request().getResourceBundle(MY_NAME, Locale.CANADA_FRENCH);
+        ResourceBundle bundle = context.jakartaRequest().getResourceBundle(MY_NAME, Locale.CANADA_FRENCH);
         assertEquals(Locale.CANADA_FRENCH, bundle.getLocale());
         assertEquals(MY_NAME, ((MockResourceBundle) bundle).getBaseName());
     }
@@ -58,25 +58,25 @@ public class MockResourceBundleProviderTest {
         assertNotNull(bundleProvider);
         bundleProvider.setDefaultLocale(Locale.KOREA);
 
-        ResourceBundle bundle = context.request().getResourceBundle(null);
+        ResourceBundle bundle = context.jakartaRequest().getResourceBundle(null);
         assertEquals(Locale.KOREA, bundle.getLocale());
         assertNull(((MockResourceBundle) bundle).getBaseName());
     }
 
     @Test
     public void testCaching() {
-        ResourceBundle bundle = context.request().getResourceBundle(Locale.GERMAN);
+        ResourceBundle bundle = context.jakartaRequest().getResourceBundle(Locale.GERMAN);
 
         ((MockResourceBundle) bundle).put("key1", "value1");
         assertEquals("value1", bundle.getString("key1"));
 
-        ResourceBundle bundle_cached = context.request().getResourceBundle(Locale.GERMAN);
+        ResourceBundle bundle_cached = context.jakartaRequest().getResourceBundle(Locale.GERMAN);
         assertEquals("value1", bundle_cached.getString("key1"));
 
-        ResourceBundle bundle_otherlocale = context.request().getResourceBundle(Locale.FRANCE);
+        ResourceBundle bundle_otherlocale = context.jakartaRequest().getResourceBundle(Locale.FRANCE);
         assertEquals("key1", bundle_otherlocale.getString("key1"));
 
-        ResourceBundle bundle_otherbasename = context.request().getResourceBundle(MY_NAME, Locale.GERMAN);
+        ResourceBundle bundle_otherbasename = context.jakartaRequest().getResourceBundle(MY_NAME, Locale.GERMAN);
         assertEquals("key1", bundle_otherbasename.getString("key1"));
     }
 }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/MockSlingScriptHelperTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/MockSlingScriptHelperTest.java
@@ -20,36 +20,54 @@ package org.apache.sling.testing.mock.sling;
 
 import java.util.Arrays;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.request.RequestDispatcherOptions;
+import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.scripting.SlingScript;
 import org.apache.sling.api.scripting.SlingScriptHelper;
+import org.apache.sling.api.wrappers.JavaxToJakartaRequestWrapper;
+import org.apache.sling.api.wrappers.JavaxToJakartaResponseWrapper;
 import org.apache.sling.testing.mock.osgi.MockOsgi;
-import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
-import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletRequest;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletResponse;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.osgi.framework.BundleContext;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class MockSlingScriptHelperTest {
 
     private ResourceResolver resourceResolver;
-    private SlingHttpServletRequest request;
-    private SlingHttpServletResponse response;
+
+    @SuppressWarnings("deprecation")
+    private org.apache.sling.api.SlingHttpServletRequest request;
+
+    @SuppressWarnings("deprecation")
+    private org.apache.sling.api.SlingHttpServletResponse response;
+
+    private MockSlingJakartaHttpServletRequest jakartaRequest;
+    private MockSlingJakartaHttpServletResponse jakartaResponse;
+
     private BundleContext bundleContext;
     private SlingScriptHelper scriptHelper;
 
+    @SuppressWarnings("deprecation")
     @Before
     public void setUp() throws Exception {
         this.bundleContext = MockOsgi.newBundleContext();
         this.resourceResolver = MockSling.newResourceResolver(bundleContext);
-        this.request = new MockSlingHttpServletRequest(this.resourceResolver, bundleContext);
-        this.response = new MockSlingHttpServletResponse();
+        jakartaRequest = new MockSlingJakartaHttpServletRequest(this.resourceResolver, this.bundleContext);
+        this.request = new org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest(jakartaRequest);
+        jakartaResponse = new MockSlingJakartaHttpServletResponse();
+        this.response = new org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse(jakartaResponse);
         this.scriptHelper = MockSling.newSlingScriptHelper(this.request, this.response, this.bundleContext);
     }
 
@@ -59,14 +77,32 @@ public class MockSlingScriptHelperTest {
         MockOsgi.shutdown(this.bundleContext);
     }
 
+    /**
+     * @deprecated use {@link #testJakartaRequest()} instead
+     */
+    @Deprecated(since = "4.0.0")
     @Test
     public void testRequest() {
         assertSame(this.request, this.scriptHelper.getRequest());
     }
 
+    /**
+     * @deprecated use {@link #testJakartaResponse()} instead
+     */
+    @Deprecated(since = "4.0.0")
     @Test
     public void testResponse() {
         assertSame(this.response, this.scriptHelper.getResponse());
+    }
+
+    @Test
+    public void testJakartaRequest() {
+        assertSame(this.jakartaRequest, this.scriptHelper.getJakartaRequest());
+    }
+
+    @Test
+    public void testJakartaResponse() {
+        assertSame(this.jakartaResponse, this.scriptHelper.getJakartaResponse());
     }
 
     @Test
@@ -84,5 +120,158 @@ public class MockSlingScriptHelperTest {
         Integer[] servicesResult = this.scriptHelper.getServices(Integer.class, null);
         Arrays.sort(servicesResult);
         assertArrayEquals(services, servicesResult);
+    }
+
+    /**
+     *
+     */
+    @Deprecated(since = "4.0.0")
+    @Test
+    public void testNewSlingScriptHelperForNotMockSlingRequest() {
+        org.apache.sling.api.SlingHttpServletRequest mockRequest =
+                Mockito.mock(org.apache.sling.api.SlingHttpServletRequest.class);
+        org.apache.sling.api.SlingHttpServletResponse mockResponse =
+                Mockito.mock(org.apache.sling.api.SlingHttpServletResponse.class);
+        SlingScriptHelper slingScriptHelper =
+                MockSling.newSlingScriptHelper(mockRequest, mockResponse, this.bundleContext);
+        assertTrue(slingScriptHelper.getJakartaRequest() instanceof JavaxToJakartaRequestWrapper);
+        assertTrue(slingScriptHelper.getJakartaResponse() instanceof JavaxToJakartaResponseWrapper);
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#getScript()}.
+     */
+    @Test
+    public void testGetScript() {
+        assertNull(this.scriptHelper.getScript());
+        SlingScript mockSlingScript = Mockito.mock(SlingScript.class);
+        ((MockSlingScriptHelper) this.scriptHelper).setScript(mockSlingScript);
+        assertSame(mockSlingScript, this.scriptHelper.getScript());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#setScript(org.apache.sling.api.scripting.SlingScript)}.
+     */
+    @Test
+    public void testSetScript() {
+        SlingScript mockSlingScript = Mockito.mock(SlingScript.class);
+        ((MockSlingScriptHelper) this.scriptHelper).setScript(mockSlingScript);
+        assertSame(mockSlingScript, this.scriptHelper.getScript());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#dispose()}.
+     */
+    @SuppressWarnings("deprecation")
+    @Deprecated
+    @Test
+    public void testDispose() {
+        assertThrows(UnsupportedOperationException.class, () -> this.scriptHelper.dispose());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#forward(java.lang.String, org.apache.sling.api.request.RequestDispatcherOptions)}.
+     */
+    @Test
+    public void testForwardStringRequestDispatcherOptions() {
+        RequestDispatcherOptions options = new RequestDispatcherOptions();
+        assertThrows(UnsupportedOperationException.class, () -> this.scriptHelper.forward("/path", options));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#forward(java.lang.String, java.lang.String)}.
+     */
+    @Test
+    public void testForwardStringString() {
+        assertThrows(UnsupportedOperationException.class, () -> this.scriptHelper.forward("/path", ""));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#forward(java.lang.String)}.
+     */
+    @Test
+    public void testForwardString() {
+        assertThrows(UnsupportedOperationException.class, () -> this.scriptHelper.forward("/path"));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#forward(org.apache.sling.api.resource.Resource)}.
+     */
+    @Test
+    public void testForwardResource() {
+        Resource resource = this.resourceResolver.resolve("/path");
+        assertThrows(UnsupportedOperationException.class, () -> this.scriptHelper.forward(resource));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#forward(org.apache.sling.api.resource.Resource, java.lang.String)}.
+     */
+    @Test
+    public void testForwardResourceString() {
+        Resource resource = this.resourceResolver.resolve("/path");
+        assertThrows(UnsupportedOperationException.class, () -> this.scriptHelper.forward(resource, ""));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#forward(org.apache.sling.api.resource.Resource, org.apache.sling.api.request.RequestDispatcherOptions)}.
+     */
+    @Test
+    public void testForwardResourceRequestDispatcherOptions() {
+        Resource resource = this.resourceResolver.resolve("/path");
+        RequestDispatcherOptions options = new RequestDispatcherOptions();
+        assertThrows(UnsupportedOperationException.class, () -> this.scriptHelper.forward(resource, options));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#include(java.lang.String, org.apache.sling.api.request.RequestDispatcherOptions)}.
+     */
+    @Test
+    public void testIncludeStringRequestDispatcherOptions() {
+        RequestDispatcherOptions options = new RequestDispatcherOptions();
+        assertThrows(UnsupportedOperationException.class, () -> this.scriptHelper.include("/path", options));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#include(java.lang.String, java.lang.String)}.
+     */
+    @Test
+    public void testIncludeStringString() {
+        assertThrows(UnsupportedOperationException.class, () -> this.scriptHelper.include("/path", ""));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#include(java.lang.String)}.
+     */
+    @Test
+    public void testIncludeString() {
+        assertThrows(UnsupportedOperationException.class, () -> this.scriptHelper.include("/path"));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#include(org.apache.sling.api.resource.Resource)}.
+     */
+    @Test
+    public void testIncludeResource() {
+        Resource resource = this.resourceResolver.resolve("/path");
+        assertThrows(UnsupportedOperationException.class, () -> this.scriptHelper.include(resource));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#include(org.apache.sling.api.resource.Resource, java.lang.String)}.
+     */
+    @Test
+    public void testIncludeResourceString() {
+        Resource resource = this.resourceResolver.resolve("/path");
+        assertThrows(UnsupportedOperationException.class, () -> this.scriptHelper.include(resource, ""));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSlingScriptHelper#include(org.apache.sling.api.resource.Resource, org.apache.sling.api.request.RequestDispatcherOptions)}.
+     */
+    @Test
+    public void testIncludeResourceRequestDispatcherOptions() {
+        Resource resource = this.resourceResolver.resolve("/path");
+        RequestDispatcherOptions options = new RequestDispatcherOptions();
+        assertThrows(UnsupportedOperationException.class, () -> this.scriptHelper.include(resource, options));
     }
 }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/MockSlingTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/MockSlingTest.java
@@ -18,9 +18,13 @@
  */
 package org.apache.sling.testing.mock.sling;
 
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.testing.mock.osgi.MockOsgi;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletRequest;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletResponse;
 import org.apache.sling.testing.mock.sling.spi.ResourceResolverTypeAdapter;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
@@ -89,5 +93,62 @@ public class MockSlingTest {
 
         assertSame(freshRepo, repo1);
         assertSame(snapshotRepo, repo2);
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSling#newSlingScriptHelper(org.apache.sling.api.SlingHttpServletRequest, org.apache.sling.api.SlingHttpServletResponse, org.osgi.framework.BundleContext)}.
+     * @deprecated use {@link #testNewSlingScriptHelperSlingJakartaHttpServletRequestSlingJakartaHttpServletResponseBundleContext() instead
+     */
+    @Deprecated(since = "4.1.0")
+    @Test
+    public void testNewSlingScriptHelperSlingHttpServletRequestSlingHttpServletResponseBundleContext() {
+        BundleContext bundleContext = MockOsgi.newBundleContext();
+        org.apache.sling.api.SlingHttpServletRequest javaxRequest =
+                new org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest(
+                        new MockSlingJakartaHttpServletRequest(bundleContext));
+        org.apache.sling.api.SlingHttpServletResponse javaxResponse =
+                new org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse(
+                        new MockSlingJakartaHttpServletResponse());
+        assertNotNull(MockSling.newSlingScriptHelper(javaxRequest, javaxResponse, bundleContext));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSling#newSlingScriptHelper(org.apache.sling.api.SlingJakartaHttpServletRequest, org.apache.sling.api.SlingJakartaHttpServletResponse, org.osgi.framework.BundleContext)}.
+     */
+    @Test
+    public void testNewSlingScriptHelperSlingJakartaHttpServletRequestSlingJakartaHttpServletResponseBundleContext() {
+        BundleContext bundleContext = MockOsgi.newBundleContext();
+        SlingJakartaHttpServletRequest jakartaRequest = new MockSlingJakartaHttpServletRequest(bundleContext);
+        SlingJakartaHttpServletResponse jakartaResponse = new MockSlingJakartaHttpServletResponse();
+        assertNotNull(MockSling.newSlingScriptHelper(jakartaRequest, jakartaResponse, bundleContext));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSling#newSlingScriptHelper(org.osgi.framework.BundleContext)}.
+     * @deprecated use {@link #testNewJakartaSlingScriptHelper()} instead
+     */
+    @Deprecated(since = "4.1.0")
+    @Test
+    public void testNewSlingScriptHelperBundleContext() {
+        BundleContext bundleContext = MockOsgi.newBundleContext();
+        assertNotNull(MockSling.newSlingScriptHelper(bundleContext));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSling#newJakartaSlingScriptHelper(org.osgi.framework.BundleContext)}.
+     */
+    @Test
+    public void testNewJakartaSlingScriptHelper() {
+        BundleContext bundleContext = MockOsgi.newBundleContext();
+        assertNotNull(MockSling.newJakartaSlingScriptHelper(bundleContext));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.MockSling#newResourceResolverFactory(org.osgi.framework.BundleContext)}.
+     */
+    @Test
+    public void testNewResourceResolverFactoryBundleContext() {
+        BundleContext bundleContext = MockOsgi.newBundleContext();
+        assertNotNull(MockSling.newResourceResolverFactory(bundleContext));
     }
 }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/builder/ImmutableValueMapTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/builder/ImmutableValueMapTest.java
@@ -24,10 +24,12 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Test.None;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class ImmutableValueMapTest {
@@ -185,5 +187,23 @@ public class ImmutableValueMapTest {
         assertEquals(map2, map1);
         assertNotEquals(map1, map3);
         assertNotEquals(map2, map3);
+
+        assertNotEquals(map1, new Object());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.builder.ImmutableValueMap#hashCode()}.
+     */
+    @Test(expected = None.class)
+    public void testHashCode() {
+        underTest.hashCode();
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.builder.ImmutableValueMap#toString()}.
+     */
+    @Test
+    public void testToString() {
+        assertNotNull(underTest.toString());
     }
 }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/context/AbstractModelAdapterFactoryUtilTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/context/AbstractModelAdapterFactoryUtilTest.java
@@ -37,8 +37,8 @@ public abstract class AbstractModelAdapterFactoryUtilTest {
 
     @Test
     public void testRequestAttribute() {
-        context().request().setAttribute("prop1", "myValue");
-        RequestAttributeModel model = context().request().adaptTo(RequestAttributeModel.class);
+        context().jakartaRequest().setAttribute("prop1", "myValue");
+        RequestAttributeModel model = context().jakartaRequest().adaptTo(RequestAttributeModel.class);
         assertNotNull(model);
         assertEquals("myValue", model.getProp1());
     }
@@ -55,14 +55,14 @@ public abstract class AbstractModelAdapterFactoryUtilTest {
 
     @Test
     public void testInvalidAdapt() {
-        OsgiServiceModel model = context().request().adaptTo(OsgiServiceModel.class);
+        OsgiServiceModel model = context().jakartaRequest().adaptTo(OsgiServiceModel.class);
         assertNull(model);
     }
 
     @Test
     public void testAdaptToInterface() {
-        context().request().setAttribute("prop1", "myValue");
-        ServiceInterface model = context().request().adaptTo(ServiceInterface.class);
+        context().jakartaRequest().setAttribute("prop1", "myValue");
+        ServiceInterface model = context().jakartaRequest().adaptTo(ServiceInterface.class);
         assertNotNull(model);
         assertEquals("myValue", model.getPropValue());
     }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/context/AbstractSlingContextImplTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/context/AbstractSlingContextImplTest.java
@@ -62,21 +62,27 @@ public abstract class AbstractSlingContextImplTest {
 
     protected abstract ResourceResolverType getResourceResolverType();
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testContextObjects() {
         assertNotNull(context.componentContext());
         assertNotNull(context.bundleContext());
         assertNotNull(context.resourceResolver());
+        assertNotNull(context.jakartaRequest());
         assertNotNull(context.request());
         assertNotNull(context.requestPathInfo());
+        assertNotNull(context.jakartaResponse());
         assertNotNull(context.response());
         assertNotNull(context.slingScriptHelper());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSlingBindings() {
         SlingBindings bindings = (SlingBindings) context.request().getAttribute(SlingBindings.class.getName());
         assertNotNull(bindings);
+        assertSame(context.jakartaRequest(), bindings.get(SlingBindings.JAKARTA_REQUEST));
+        assertSame(context.jakartaResponse(), bindings.get(SlingBindings.JAKARTA_RESPONSE));
         assertSame(context.request(), bindings.get(SlingBindings.REQUEST));
         assertSame(context.response(), bindings.get(SlingBindings.RESPONSE));
         assertSame(context.slingScriptHelper(), bindings.get(SlingBindings.SLING));
@@ -85,8 +91,8 @@ public abstract class AbstractSlingContextImplTest {
     @Test
     public void testNonMockedSlingBindings() {
         final SlingBindings slingBindings = new SlingBindings();
-        context.request().setAttribute(SlingBindings.class.getName(), slingBindings);
-        SlingBindings bindings = (SlingBindings) context.request().getAttribute(SlingBindings.class.getName());
+        context.jakartaRequest().setAttribute(SlingBindings.class.getName(), slingBindings);
+        SlingBindings bindings = (SlingBindings) context.jakartaRequest().getAttribute(SlingBindings.class.getName());
         assertNotNull(bindings);
     }
 
@@ -102,10 +108,10 @@ public abstract class AbstractSlingContextImplTest {
                 "/content/sample/en/jcr:content/par", context.currentResource().getPath());
 
         context.currentResource((Resource) null);
-        assertNull(context.request().getResource());
+        assertNull(context.jakartaRequest().getResource());
 
         context.currentResource((String) null);
-        assertNull(context.request().getResource());
+        assertNull(context.jakartaRequest().getResource());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -115,8 +121,8 @@ public abstract class AbstractSlingContextImplTest {
 
     @Test
     public void testSlingModelsRequestAttribute() {
-        context.request().setAttribute("prop1", "myValue");
-        RequestAttributeModel model = context.request().adaptTo(RequestAttributeModel.class);
+        context.jakartaRequest().setAttribute("prop1", "myValue");
+        RequestAttributeModel model = context.jakartaRequest().adaptTo(RequestAttributeModel.class);
         assertEquals("myValue", model.getProp1());
     }
 
@@ -131,21 +137,21 @@ public abstract class AbstractSlingContextImplTest {
 
     @Test
     public void testSlingModelsInvalidAdapt() {
-        OsgiServiceModel model = context.request().adaptTo(OsgiServiceModel.class);
+        OsgiServiceModel model = context.jakartaRequest().adaptTo(OsgiServiceModel.class);
         assertNull(model);
     }
 
     @Test
-    public void testSlnigModelClasspathRegistered() {
-        context.request().setAttribute("prop1", "myValue");
-        ClasspathRegisteredModel model = context.request().adaptTo(ClasspathRegisteredModel.class);
+    public void testSlingModelClasspathRegistered() {
+        context.jakartaRequest().setAttribute("prop1", "myValue");
+        ClasspathRegisteredModel model = context.jakartaRequest().adaptTo(ClasspathRegisteredModel.class);
         assertEquals("myValue", model.getProp1());
     }
 
     @Test
     public void testAdaptToInterface() {
-        context.request().setAttribute("prop1", "myValue");
-        ServiceInterface model = context.request().adaptTo(ServiceInterface.class);
+        context.jakartaRequest().setAttribute("prop1", "myValue");
+        ServiceInterface model = context.jakartaRequest().adaptTo(ServiceInterface.class);
         assertNotNull(model);
         assertEquals("myValue", model.getPropValue());
     }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/context/NoSlingModelsRegistrationTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/context/NoSlingModelsRegistrationTest.java
@@ -34,9 +34,9 @@ public class NoSlingModelsRegistrationTest {
             new SlingContextBuilder().registerSlingModelsFromClassPath(false).build();
 
     @Test
-    public void testSlnigModelClasspathRegistered() {
-        context.request().setAttribute("prop1", "myValue");
-        ClasspathRegisteredModel model = context.request().adaptTo(ClasspathRegisteredModel.class);
+    public void testSlingModelClasspathRegistered() {
+        context.jakartaRequest().setAttribute("prop1", "myValue");
+        ClasspathRegisteredModel model = context.jakartaRequest().adaptTo(ClasspathRegisteredModel.class);
         // expect null because ClasspathRegisteredModel should not be registered automatically from classpath
         assertNull(model);
     }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/context/SlingBindingsTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/context/SlingBindingsTest.java
@@ -80,14 +80,17 @@ public class SlingBindingsTest {
         Thread.sleep(25);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testModelBindings() {
-        SlingBindingsModel model = context.request().adaptTo(SlingBindingsModel.class);
+        SlingBindingsModel model = context.jakartaRequest().adaptTo(SlingBindingsModel.class);
 
         assertNotNull(model);
         assertNotNull(model.getResolver());
         assertNotNull(model.getResource());
         assertEquals(currentResource.getPath(), model.getResource().getPath());
+        assertNotNull(model.getJakartaRequest());
+        assertNotNull(model.getJakartaResponse());
         assertNotNull(model.getRequest());
         assertNotNull(model.getResponse());
         assertNotNull(model.getCurrentNode());
@@ -99,7 +102,7 @@ public class SlingBindingsTest {
 
     @Test
     public void testCustomBindingsValuesProvider() {
-        SlingBindings bindings = (SlingBindings) context.request().getAttribute(SlingBindings.class.getName());
+        SlingBindings bindings = (SlingBindings) context.jakartaRequest().getAttribute(SlingBindings.class.getName());
         assertNotNull(bindings);
         assertEquals(currentResource.getPath(), bindings.getResource().getPath());
         assertEquals("value-1", bindings.get("custom-param-1"));

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/context/models/RequestAttributeModel.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/context/models/RequestAttributeModel.java
@@ -20,13 +20,13 @@ package org.apache.sling.testing.mock.sling.context.models;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
 /**
  * For testing Sling Models support.
  */
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public interface RequestAttributeModel {
 
     @Inject

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/context/models/ServiceInterfaceImpl.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/context/models/ServiceInterfaceImpl.java
@@ -20,13 +20,13 @@ package org.apache.sling.testing.mock.sling.context.models;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
 /**
  * For testing Sling Models support.
  */
-@Model(adaptables = SlingHttpServletRequest.class, adapters = ServiceInterface.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class, adapters = ServiceInterface.class)
 public class ServiceInterfaceImpl implements ServiceInterface {
 
     @Inject

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/context/models/SlingBindingsModel.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/context/models/SlingBindingsModel.java
@@ -21,15 +21,15 @@ package org.apache.sling.testing.mock.sling.context.models;
 import javax.jcr.Node;
 import javax.jcr.Session;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public interface SlingBindingsModel {
 
     // -- Sling --
@@ -39,11 +39,25 @@ public interface SlingBindingsModel {
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
     Resource getResource();
 
+    /**
+     * @deprecated use {@link #getJakartaRequest()} instead
+     */
+    @Deprecated(since = "4.0.0")
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
-    SlingHttpServletRequest getRequest();
+    org.apache.sling.api.SlingHttpServletRequest getRequest();
+
+    /**
+     * @deprecated use {@link #getJakartaResponse()} instead
+     */
+    @Deprecated(since = "4.0.0")
+    @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
+    org.apache.sling.api.SlingHttpServletResponse getResponse();
 
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
-    SlingHttpServletResponse getResponse();
+    SlingJakartaHttpServletRequest getJakartaRequest();
+
+    @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
+    SlingJakartaHttpServletResponse getJakartaResponse();
 
     // -- JCR --
     @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/context/modelsautoreg/ClasspathRegisteredModel.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/context/modelsautoreg/ClasspathRegisteredModel.java
@@ -20,14 +20,14 @@ package org.apache.sling.testing.mock.sling.context.modelsautoreg;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
 /**
  * For testing Sling Models support.
  * This model is registered automatically via OSGi metadata (MANIFEST) in the classpath.
  */
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public interface ClasspathRegisteredModel {
 
     @Inject

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/resource/AbstractSlingCrudResourceResolverTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/resource/AbstractSlingCrudResourceResolverTest.java
@@ -32,7 +32,7 @@ import java.util.TreeMap;
 import org.apache.commons.collections4.IterableUtils;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
@@ -236,7 +236,7 @@ public abstract class AbstractSlingCrudResourceResolverTest {
 
     private boolean containsResource(List<Resource> children, Resource resource) {
         for (Resource child : children) {
-            if (StringUtils.equals(child.getPath(), resource.getPath())) {
+            if (Strings.CS.equals(child.getPath(), resource.getPath())) {
                 return true;
             }
         }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/rpmock/resource/SlingCrudResourceResolverTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/rpmock/resource/SlingCrudResourceResolverTest.java
@@ -41,9 +41,10 @@ public class SlingCrudResourceResolverTest extends AbstractSlingCrudResourceReso
         // ensure there is a method getSearchPaths in resource resolver factory, although it is not part of the API we
         // are compiling against (keeping backward compatibility)
         ResourceResolverFactory factory = context.getService(ResourceResolverFactory.class);
-        Class clazz = factory.getClass();
+        Class<? extends ResourceResolverFactory> clazz = factory.getClass();
         Method getSearchPathMethod = clazz.getMethod("getSearchPath");
         getSearchPathMethod.setAccessible(true);
+        @SuppressWarnings("rawtypes")
         List<String> searchPaths = (List) getSearchPathMethod.invoke(factory);
         assertNotNull(searchPaths);
     }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/rrmock/resource/SlingCrudResourceResolverTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/rrmock/resource/SlingCrudResourceResolverTest.java
@@ -41,9 +41,10 @@ public class SlingCrudResourceResolverTest extends AbstractSlingCrudResourceReso
         // ensure there is a method getSearchPaths in resource resolver factory, although it is not part of the API we
         // are compiling against (keeping backward compatibility)
         ResourceResolverFactory factory = context.getService(ResourceResolverFactory.class);
-        Class clazz = factory.getClass();
+        Class<? extends ResourceResolverFactory> clazz = factory.getClass();
         Method getSearchPathMethod = clazz.getMethod("getSearchPath");
         getSearchPathMethod.setAccessible(true);
+        @SuppressWarnings("rawtypes")
         List<String> searchPaths = (List) getSearchPathMethod.invoke(factory);
         assertNotNull(searchPaths);
     }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/services/MockSlingSettingServiceTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/services/MockSlingSettingServiceTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class MockSlingSettingServiceTest {
@@ -53,5 +54,59 @@ public class MockSlingSettingServiceTest {
     @Test
     public void slingId() {
         assertThat(new MockSlingSettingService().getSlingId(), notNullValue());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.services.MockSlingSettingService#getAbsolutePathWithinSlingHome(java.lang.String)}.
+     */
+    @Test()
+    public void testGetAbsolutePathWithinSlingHome() {
+        MockSlingSettingService underTest = new MockSlingSettingService();
+        assertThrows(UnsupportedOperationException.class, () -> underTest.getAbsolutePathWithinSlingHome("relPath1"));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.services.MockSlingSettingService#getSlingHomePath()}.
+     */
+    @Test
+    public void testGetSlingHomePath() {
+        MockSlingSettingService underTest = new MockSlingSettingService();
+        assertThrows(UnsupportedOperationException.class, () -> underTest.getSlingHomePath());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.services.MockSlingSettingService#getSlingHome()}.
+     */
+    @Test
+    public void testGetSlingHome() {
+        MockSlingSettingService underTest = new MockSlingSettingService();
+        assertThrows(UnsupportedOperationException.class, () -> underTest.getSlingHome());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.services.MockSlingSettingService#getSlingName()}.
+     */
+    @Test
+    public void testGetSlingName() {
+        MockSlingSettingService underTest = new MockSlingSettingService();
+        assertThrows(UnsupportedOperationException.class, () -> underTest.getSlingName());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.services.MockSlingSettingService#getSlingDescription()}.
+     */
+    @Test
+    public void testGetSlingDescription() {
+        MockSlingSettingService underTest = new MockSlingSettingService();
+        assertThrows(UnsupportedOperationException.class, () -> underTest.getSlingDescription());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.services.MockSlingSettingService#getBestRunModeMatchCountFromSpec(java.lang.String)}.
+     */
+    @Test
+    public void testGetBestRunModeMatchCountFromSpec() {
+        MockSlingSettingService underTest = new MockSlingSettingService();
+        assertThrows(UnsupportedOperationException.class, () -> underTest.getBestRunModeMatchCountFromSpec("test"));
     }
 }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/servlet/MockHttpSessionTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/servlet/MockHttpSessionTest.java
@@ -18,19 +18,26 @@
  */
 package org.apache.sling.testing.mock.sling.servlet;
 
+import org.apache.sling.servlethelpers.MockJakartaHttpSession;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Mock {@link javax.servlet.http.HttpSession} tests.
+ *
+ * @deprecated Use {@link MockJakartaHttpSessionTest} instead.
+ */
+@Deprecated(since = "4.0.0")
 public class MockHttpSessionTest {
 
     private MockHttpSession httpSession;
 
     @Before
     public void setUp() throws Exception {
-        httpSession = new MockHttpSession();
+        httpSession = new MockHttpSession(new MockJakartaHttpSession());
     }
 
     @Test

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/servlet/MockJakartaHttpSessionTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/servlet/MockJakartaHttpSessionTest.java
@@ -18,18 +18,24 @@
  */
 package org.apache.sling.testing.mock.sling.servlet;
 
-/**
- * Mock {@link javax.servlet.ServletContext} implementation.
- *
- * @deprecated Use {@link MockJakartaServletContext} instead.
- */
-@Deprecated(since = "3.2.0")
-public final class MockServletContext extends org.apache.sling.servlethelpers.MockServletContext {
+import org.junit.Before;
+import org.junit.Test;
 
-    public MockServletContext(org.apache.sling.servlethelpers.MockJakartaServletContext wrappedServletContext) {
-        super(wrappedServletContext);
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class MockJakartaHttpSessionTest {
+
+    private MockJakartaHttpSession httpSession;
+
+    @Before
+    public void setUp() throws Exception {
+        httpSession = new MockJakartaHttpSession();
     }
 
-    // inherit from superclass
-
+    @Test
+    public void testServletContext() {
+        assertNotNull(httpSession.getServletContext());
+        assertTrue(httpSession.getServletContext() instanceof MockJakartaServletContext);
+    }
 }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/servlet/MockRequestPathInfoTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/servlet/MockRequestPathInfoTest.java
@@ -18,29 +18,32 @@
  */
 package org.apache.sling.testing.mock.sling.servlet;
 
-import org.junit.Before;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.junit.Test;
-
-import static org.junit.Assert.assertNull;
+import org.junit.Test.None;
+import org.mockito.Mockito;
 
 /**
- * Mock {@link org.apache.sling.api.SlingHttpServletResponse} tests.
  *
- * @deprecated Use {@link MockSlingJakartaHttpServletResponse} instead.
  */
-@Deprecated(since = "4.0.0")
-public class MockSlingHttpServletResponseTest {
+public class MockRequestPathInfoTest {
 
-    private MockSlingHttpServletResponse response;
-
-    @Before
-    public void setUp() throws Exception {
-        this.response = new MockSlingHttpServletResponse(new MockSlingJakartaHttpServletResponse());
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.servlet.MockRequestPathInfo#MockRequestPathInfo()}.
+     * @deprecated use {@link #testMockRequestPathInfoResourceResolver()} instead
+     */
+    @Deprecated
+    @Test(expected = None.class)
+    public void testMockRequestPathInfo() {
+        new MockRequestPathInfo();
     }
 
-    @Test
-    public void testContentTypeCharset() throws Exception {
-        assertNull(response.getContentType());
-        assertNull(response.getCharacterEncoding());
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.servlet.MockRequestPathInfo#MockRequestPathInfo(org.apache.sling.api.resource.ResourceResolver)}.
+     */
+    @Test(expected = None.class)
+    public void testMockRequestPathInfoResourceResolver() {
+        ResourceResolver mockResourceResolver = Mockito.mock(ResourceResolver.class);
+        new MockRequestPathInfo(mockResourceResolver);
     }
 }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/servlet/MockSlingJakartaHttpServletRequestTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/servlet/MockSlingJakartaHttpServletRequestTest.java
@@ -18,16 +18,14 @@
  */
 package org.apache.sling.testing.mock.sling.servlet;
 
-import javax.servlet.http.HttpSession;
-
 import java.util.ListResourceBundle;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
+import jakarta.servlet.http.HttpSession;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.i18n.ResourceBundleProvider;
-import org.apache.sling.servlethelpers.MockHttpSession;
 import org.apache.sling.servlethelpers.MockRequestPathInfo;
 import org.apache.sling.testing.mock.osgi.MockOsgi;
 import org.junit.After;
@@ -47,15 +45,9 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/**
- * Mock {@link org.apache.sling.api.SlingHttpServletRequest} tests.
- *
- * @deprecated Use {@link MockSlingJakartaHttpServletRequest} instead.
- */
-@Deprecated(since = "4.0.0")
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("null")
-public class MockSlingHttpServletRequestTest {
+public class MockSlingJakartaHttpServletRequestTest {
 
     @Mock
     private ResourceResolver resourceResolver;
@@ -65,13 +57,11 @@ public class MockSlingHttpServletRequestTest {
 
     private BundleContext bundleContext = MockOsgi.newBundleContext();
 
-    private MockSlingHttpServletRequest request;
+    private MockSlingJakartaHttpServletRequest request;
 
     @Before
     public void setUp() throws Exception {
-        MockSlingJakartaHttpServletRequest jakartaRequest =
-                new MockSlingJakartaHttpServletRequest(resourceResolver, bundleContext);
-        request = new MockSlingHttpServletRequest(jakartaRequest);
+        request = new MockSlingJakartaHttpServletRequest(resourceResolver, bundleContext);
     }
 
     @After
@@ -86,14 +76,14 @@ public class MockSlingHttpServletRequestTest {
 
     @Test
     public void testDefaultResourceResolver() {
-        assertNotNull(new MockSlingHttpServletRequest(bundleContext).getResourceResolver());
+        assertNotNull(new MockSlingJakartaHttpServletRequest(bundleContext).getResourceResolver());
     }
 
     @Test
     public void testSession() {
         HttpSession session = request.getSession();
         assertNotNull(session);
-        assertTrue(session instanceof MockHttpSession);
+        assertTrue(session instanceof MockJakartaHttpSession);
     }
 
     @Test

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/servlet/MockSlingJakartaHttpServletResponseTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/servlet/MockSlingJakartaHttpServletResponseTest.java
@@ -18,18 +18,23 @@
  */
 package org.apache.sling.testing.mock.sling.servlet;
 
-/**
- * Mock {@link javax.servlet.ServletContext} implementation.
- *
- * @deprecated Use {@link MockJakartaServletContext} instead.
- */
-@Deprecated(since = "3.2.0")
-public final class MockServletContext extends org.apache.sling.servlethelpers.MockServletContext {
+import org.junit.Before;
+import org.junit.Test;
 
-    public MockServletContext(org.apache.sling.servlethelpers.MockJakartaServletContext wrappedServletContext) {
-        super(wrappedServletContext);
+import static org.junit.Assert.assertNull;
+
+public class MockSlingJakartaHttpServletResponseTest {
+
+    private MockSlingJakartaHttpServletResponse response;
+
+    @Before
+    public void setUp() throws Exception {
+        this.response = new MockSlingJakartaHttpServletResponse();
     }
 
-    // inherit from superclass
-
+    @Test
+    public void testContentTypeCharset() throws Exception {
+        assertNull(response.getContentType());
+        assertNull(response.getCharacterEncoding());
+    }
 }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/spi/ResourceResolverTypeAdapterTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/spi/ResourceResolverTypeAdapterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.testing.mock.sling.spi;
+
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.jcr.api.SlingRepository;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+/**
+ *
+ */
+public class ResourceResolverTypeAdapterTest {
+    private ResourceResolverTypeAdapter mockAdapter = new ResourceResolverTypeAdapter() {
+        @Override
+        public @Nullable SlingRepository newSlingRepository() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public @Nullable ResourceResolverFactory newResourceResolverFactory() {
+            throw new UnsupportedOperationException();
+        }
+    };
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.spi.ResourceResolverTypeAdapter#snapshot(org.apache.sling.jcr.api.SlingRepository)}.
+     */
+    @Test
+    public void testSnapshot() {
+        SlingRepository mockSlingRepository = Mockito.mock(SlingRepository.class);
+        assertNull(mockAdapter.snapshot(mockSlingRepository));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.testing.mock.sling.spi.ResourceResolverTypeAdapter#newSlingRepositoryFromSnapshot(java.lang.Object)}.
+     */
+    @Test
+    public void testNewSlingRepositoryFromSnapshot() {
+        Object snapshot = new Object();
+        assertThrows(UnsupportedOperationException.class, () -> mockAdapter.newSlingRepositoryFromSnapshot(snapshot));
+    }
+}

--- a/junit4/pom.xml
+++ b/junit4/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.testing.sling-mock.parent</artifactId>
-        <version>3.5.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -37,13 +37,13 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.core</artifactId>
-            <version>3.5.5-SNAPSHOT</version>
+            <version>4.0.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.core</artifactId>
-            <version>3.5.5-SNAPSHOT</version>
+            <version>4.0.0-SNAPSHOT</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/junit4/src/test/java/org/apache/sling/testing/mock/sling/junit/SlingContextTest.java
+++ b/junit4/src/test/java/org/apache/sling/testing/mock/sling/junit/SlingContextTest.java
@@ -66,9 +66,18 @@ public class SlingContextTest {
         verify(contextAfterSetup).execute(context);
     }
 
+    /**
+     * @deprecated use {@link #testJakartaRequest()} instead
+     */
+    @Deprecated(since = "4.0.0")
     @Test
     public void testRequest() {
         assertNotNull(context.request());
+    }
+
+    @Test
+    public void testJakartaRequest() {
+        assertNotNull(context.jakartaRequest());
     }
 
     /**

--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.testing.sling-mock.parent</artifactId>
-        <version>3.5.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -51,13 +51,13 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.core</artifactId>
-            <version>3.5.5-SNAPSHOT</version>
+            <version>4.0.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.core</artifactId>
-            <version>3.5.5-SNAPSHOT</version>
+            <version>4.0.0-SNAPSHOT</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/junit5/src/test/java/org/apache/sling/testing/mock/sling/junit5/NoSlingModelsRegistrationTest.java
+++ b/junit5/src/test/java/org/apache/sling/testing/mock/sling/junit5/NoSlingModelsRegistrationTest.java
@@ -37,8 +37,8 @@ class NoSlingModelsRegistrationTest {
     @Test
     @SuppressWarnings("null")
     public void testSlingModelClasspathRegistered() {
-        context.request().setAttribute("prop1", "myValue");
-        ClasspathRegisteredModel model = context.request().adaptTo(ClasspathRegisteredModel.class);
+        context.jakartaRequest().setAttribute("prop1", "myValue");
+        ClasspathRegisteredModel model = context.jakartaRequest().adaptTo(ClasspathRegisteredModel.class);
         // expect null because ClasspathRegisteredModel should not be registered
         // automatically from classpath
         assertNull(model);

--- a/junit5/src/test/java/org/apache/sling/testing/mock/sling/junit5/SlingContextPluginTest.java
+++ b/junit5/src/test/java/org/apache/sling/testing/mock/sling/junit5/SlingContextPluginTest.java
@@ -60,10 +60,20 @@ class SlingContextPluginTest {
         verify(contextBeforeSetup).execute(context);
     }
 
+    /**
+     * @deprecated use {@link #testJakartaRequest()} instead
+     */
+    @Deprecated(since = "4.0.0")
     @Test
     public void testRequest() throws Exception {
         verify(contextAfterSetup).execute(context);
         assertNotNull(context.request());
+    }
+
+    @Test
+    public void testJakartaRequest() throws Exception {
+        verify(contextAfterSetup).execute(context);
+        assertNotNull(context.jakartaRequest());
     }
 
     @Test
@@ -97,8 +107,8 @@ class SlingContextPluginTest {
 
     @Test
     public void testSlingModelClasspathRegistered() {
-        context.request().setAttribute("prop1", "myValue");
-        ClasspathRegisteredModel model = context.request().adaptTo(ClasspathRegisteredModel.class);
+        context.jakartaRequest().setAttribute("prop1", "myValue");
+        ClasspathRegisteredModel model = context.jakartaRequest().adaptTo(ClasspathRegisteredModel.class);
         assertEquals("myValue", model.getProp1());
     }
 

--- a/junit5/src/test/java/org/apache/sling/testing/mock/sling/junit5/SlingContextTest.java
+++ b/junit5/src/test/java/org/apache/sling/testing/mock/sling/junit5/SlingContextTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test with {@link SlingContext} as test method parameter.
@@ -42,6 +43,20 @@ class SlingContextTest {
         context.create().resource("/content/test", "prop1", "value1");
     }
 
+    /**
+     * @deprecated use {@link #testJakartaRequest()} instead
+     */
+    @Deprecated(since = "4.0.0")
+    @Test
+    public void testRequest(SlingContext context) {
+        assertNotNull(context.request());
+    }
+
+    @Test
+    public void testJakartaRequest(SlingContext context) {
+        assertNotNull(context.jakartaRequest());
+    }
+
     @Test
     void testResource(SlingContext context) {
         Resource resource = context.resourceResolver().getResource("/content/test");
@@ -50,8 +65,8 @@ class SlingContextTest {
 
     @Test
     void testSlingModelClasspathRegistered(SlingContext context) {
-        context.request().setAttribute("prop1", "myValue");
-        ClasspathRegisteredModel model = context.request().adaptTo(ClasspathRegisteredModel.class);
+        context.jakartaRequest().setAttribute("prop1", "myValue");
+        ClasspathRegisteredModel model = context.jakartaRequest().adaptTo(ClasspathRegisteredModel.class);
         assertEquals("myValue", model.getProp1());
     }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>org.apache.sling.testing.sling-mock.parent</artifactId>
-    <version>3.5.5-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Apache Sling Testing Sling Mock Parent</name>
@@ -43,7 +43,7 @@
 
     <properties>
         <project.build.outputTimestamp>2025-03-17T15:54:29Z</project.build.outputTimestamp>
-        <sling.java.version>11</sling.java.version>
+        <sling.java.version>17</sling.java.version>
     </properties>
 
     <dependencyManagement>
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.testing.resourceresolver-mock</artifactId>
-                <version>1.5.0</version>
+                <version>2.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.sling</groupId>
@@ -77,7 +77,7 @@
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.servlet-helpers</artifactId>
-                <version>1.4.6</version>
+                <version>2.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.sling</groupId>
@@ -108,22 +108,22 @@
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.models.api</artifactId>
-                <version>1.3.8</version>
+                <version>2.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.models.impl</artifactId>
-                <version>1.4.14</version>
+                <version>2.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.api</artifactId>
-                <version>2.25.4</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.resourceresolver</artifactId>
-                <version>1.7.10</version>
+                <version>2.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.sling</groupId>
@@ -148,7 +148,7 @@
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.scripting.core</artifactId>
-                <version>2.3.2</version>
+                <version>3.0.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.osgi</groupId>
@@ -183,7 +183,7 @@
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.i18n</artifactId>
-                <version>2.6.2</version>
+                <version>3.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.sling</groupId>
@@ -244,13 +244,29 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.13.0</version>
+                <version>3.18.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
-                <version>1.5</version>
+                <version>1.6.0</version>
             </dependency>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>4.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>6.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.http.wrappers</artifactId>
+                <version>1.1.10</version>
+            </dependency>
+
             <dependency>
                 <groupId>jakarta.json</groupId>
                 <artifactId>jakarta.json-api</artifactId>
@@ -356,22 +372,22 @@
                     <dependency>
                         <groupId>org.apache.sling</groupId>
                         <artifactId>org.apache.sling.models.api</artifactId>
-                        <version>1.5.4</version>
+                        <version>2.0.0-SNAPSHOT</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.sling</groupId>
                         <artifactId>org.apache.sling.models.impl</artifactId>
-                        <version>1.7.0</version>
+                        <version>2.0.0-SNAPSHOT</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.sling</groupId>
                         <artifactId>org.apache.sling.api</artifactId>
-                        <version>2.27.6</version>
+                        <version>3.0.0</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.sling</groupId>
                         <artifactId>org.apache.sling.resourceresolver</artifactId>
-                        <version>1.12.0</version>
+                        <version>2.0.0</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.sling</groupId>
@@ -396,7 +412,7 @@
                     <dependency>
                         <groupId>org.apache.sling</groupId>
                         <artifactId>org.apache.sling.scripting.core</artifactId>
-                        <version>2.4.10</version>
+                        <version>3.0.0</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.sling</groupId>
@@ -416,7 +432,7 @@
                     <dependency>
                         <groupId>org.apache.sling</groupId>
                         <artifactId>org.apache.sling.i18n</artifactId>
-                        <version>2.6.4</version>
+                        <version>3.0.0-SNAPSHOT</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.sling</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.testing.sling-mock.parent</artifactId>
-        <version>3.5.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>parent/pom.xml</relativePath>
     </parent>
 

--- a/relocate/pom.xml
+++ b/relocate/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.testing.sling-mock.parent</artifactId>
-        <version>3.5.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
bump bundle major version to 4.0.0
bump minimum java version to 17

bump org.apache.sling.testing.resourceresolver-mock to 2.0.0-SNAPSHOT (see [SLING-12840](https://issues.apache.org/jira/browse/SLING-12840))
bump org.apache.sling.servlet-helpers to 2.0.0-SNAPSHOT (see [SLING-12858](https://issues.apache.org/jira/browse/SLING-12858))

bump org.apache.sling.models.api to 2.0.0-SNAPSHOT (see [SLING-12874](https://issues.apache.org/jira/browse/SLING-12874))
bump org.apache.sling.models.impl to 2.0.0-SNAPSHOT (see [SLING-12875](https://issues.apache.org/jira/browse/SLING-12875))

bump org.apache.sling.api to 3.0.0
bump org.apache.sling.resourceresolver to 2.0.0
bump org.apache.sling.scripting.core to 3.0.0

bump org.apache.sling.i18n to 3.0.0-SNAPSHOT (see [SLING-12312](https://issues.apache.org/jira/browse/SLING-12312))

migrate the javax.servlet references in non-pubic classes to jakarta.servlet
deprecate all the remaining classes that touch javax.*
add additional tests to improve code coverage
resolve various sonar warnings