### PR TITLE
SLING-13146 ThreadsafeMockAdapterManagerWrapper: Reuse bundle context for child threads (3.x)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -295,6 +295,12 @@
             <version>1.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.3.0</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapper.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapper.java
@@ -88,7 +88,7 @@ class ThreadsafeMockAdapterManagerWrapper implements AdapterManager {
         }
 
         AdapterManagerBundleContextFactory(AdapterManagerBundleContextFactory parent) {
-            // take over bundle context from parent thread if available
+            this.parent = parent;
             this.bundleContext = parent.bundleContext;
         }
 

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapper.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapper.java
@@ -48,9 +48,7 @@ class ThreadsafeMockAdapterManagerWrapper implements AdapterManager {
                 @Override
                 protected AdapterManagerBundleContextFactory childValue(
                         AdapterManagerBundleContextFactory parentValue) {
-                    // Create a new instance for child threads instead of sharing the parent's instance
-                    // This prevents race conditions when parent and child threads have different lifecycles
-                    return new AdapterManagerBundleContextFactory();
+                    return new AdapterManagerBundleContextFactory(parentValue);
                 }
             };
 
@@ -81,21 +79,40 @@ class ThreadsafeMockAdapterManagerWrapper implements AdapterManager {
 
     private static class AdapterManagerBundleContextFactory {
 
+        private AdapterManagerBundleContextFactory parent;
         private BundleContext bundleContext;
 
+        AdapterManagerBundleContextFactory() {
+            // default constructor
+        }
+
+        AdapterManagerBundleContextFactory(AdapterManagerBundleContextFactory parent) {
+            // take over bundle context from parent thread if available
+            this.bundleContext = parent.bundleContext;
+        }
+
         public void setBundleContext(@NotNull final BundleContext bundleContext) {
-            log.debug("Set bundle context for AdapterManager, bundleContext={}", bundleContext);
+            log.debug(
+                    "Set bundle context for AdapterManager, bundleContext={}, factory={}, parent={}",
+                    bundleContext,
+                    this,
+                    parent);
             this.bundleContext = bundleContext;
 
             // register adapter manager
             MockAdapterManagerImpl adapterManagerImpl = new MockAdapterManagerImpl();
-            Dictionary<String, Object> properties = new Hashtable<String, Object>();
+            Dictionary<String, Object> properties = new Hashtable<>();
             MockOsgi.injectServices(adapterManagerImpl, bundleContext);
             MockOsgi.activate(adapterManagerImpl, bundleContext, properties);
             bundleContext.registerService(AdapterManager.class.getName(), adapterManagerImpl, properties);
         }
 
         public void clearBundleContext() {
+            log.debug(
+                    "Clear bundle context for AdapterManager, bundleContext={}, factory={}, parent={}",
+                    bundleContext,
+                    this,
+                    parent);
             this.bundleContext = null;
         }
 
@@ -104,12 +121,19 @@ class ThreadsafeMockAdapterManagerWrapper implements AdapterManager {
             if (bundleContext == null) {
                 BundleContext newBundleContext = MockOsgi.newBundleContext();
                 log.warn(
-                        "Create new bundle context for adapter manager because it was null, bundleContext={}",
-                        bundleContext);
+                        "Create new bundle context for adapter manager because it was null, bundleContext={}, factory={}, parent={}",
+                        bundleContext,
+                        this,
+                        parent);
                 setBundleContext(newBundleContext);
             }
             ServiceReference<AdapterManager> serviceReference = bundleContext.getServiceReference(AdapterManager.class);
             if (serviceReference != null) {
+                log.trace(
+                        "Get AdapterManager service from bundle context, bundleContext={}, factory={}, parent={}",
+                        bundleContext,
+                        this,
+                        parent);
                 return bundleContext.getService(serviceReference);
             } else {
                 throw new RuntimeException("AdapterManager not registered in bundle context.");

--- a/core/src/main/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapper.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapper.java
@@ -48,6 +48,7 @@ class ThreadsafeMockAdapterManagerWrapper implements AdapterManager {
                 @Override
                 protected AdapterManagerBundleContextFactory childValue(
                         AdapterManagerBundleContextFactory parentValue) {
+                    // create new factory for child thread, taking over bundle context from parent thread if available
                     return new AdapterManagerBundleContextFactory(parentValue);
                 }
             };

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapperTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapperTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.testing.mock.sling;
+
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.junit.SlingContextBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertNotNull;
+
+public class ThreadsafeMockAdapterManagerWrapperTest {
+    @Rule
+    public final SlingContext context =
+            new SlingContextBuilder().registerSlingModelsFromClassPath(false).build();
+
+    @Before
+    public void setUp() {
+        context.registerAdapter(Resource.class, AdapterClass.class, new AdapterClass());
+    }
+
+    @Test
+    public void x() {
+        assertNotNull(context.create().resource("/content/test").adaptTo(AdapterClass.class));
+        final MyService myService = context.registerService(new MyService());
+        final ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);
+        executor.schedule(
+                () -> myService.onChange(
+                        Objects.requireNonNull(context.resourceResolver().getResource("/content/test"))),
+                2,
+                TimeUnit.SECONDS);
+        await().until(() -> myService.getValue() != null);
+    }
+
+    private static class AdapterClass {}
+
+    private static class MyService {
+        private AdapterClass value;
+
+        public AdapterClass getValue() {
+            System.out.println("Returning value: " + this.value);
+            return this.value;
+        }
+
+        public void onChange(@NotNull Resource list) {
+            System.out.println("ON CHANGE");
+            final AdapterClass result = list.adaptTo(AdapterClass.class);
+            System.out.println("Result: " + result);
+            value = result;
+        }
+    }
+}

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapperTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapperTest.java
@@ -35,6 +35,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertNotNull;
 
 public class ThreadsafeMockAdapterManagerWrapperTest {
+
     @Rule
     public final SlingContext context = new SlingContextBuilder(ResourceResolverType.RESOURCEPROVIDER_MOCK)
             .registerSlingModelsFromClassPath(false)
@@ -46,7 +47,7 @@ public class ThreadsafeMockAdapterManagerWrapperTest {
     }
 
     @Test
-    public void x() {
+    public void testAdaptionInChildThread() {
         assertNotNull(context.create().resource("/content/test").adaptTo(AdapterClass.class));
         final MyService myService = context.registerService(new MyService());
         final ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);
@@ -64,14 +65,11 @@ public class ThreadsafeMockAdapterManagerWrapperTest {
         private AdapterClass value;
 
         public AdapterClass getValue() {
-            System.out.println("Returning value: " + this.value);
             return this.value;
         }
 
         public void onChange(@NotNull Resource list) {
-            System.out.println("ON CHANGE");
             final AdapterClass result = list.adaptTo(AdapterClass.class);
-            System.out.println("Result: " + result);
             value = result;
         }
     }

--- a/core/src/test/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapperTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/sling/ThreadsafeMockAdapterManagerWrapperTest.java
@@ -36,8 +36,9 @@ import static org.junit.Assert.assertNotNull;
 
 public class ThreadsafeMockAdapterManagerWrapperTest {
     @Rule
-    public final SlingContext context =
-            new SlingContextBuilder().registerSlingModelsFromClassPath(false).build();
+    public final SlingContext context = new SlingContextBuilder(ResourceResolverType.RESOURCEPROVIDER_MOCK)
+            .registerSlingModelsFromClassPath(false)
+            .build();
 
     @Before
     public void setUp() {


### PR DESCRIPTION
for 3.x branch